### PR TITLE
FE-feat-ShortChips 2종 생성

### DIFF
--- a/client/src/components/atoms/button/CreateButton/CreateButton.stories.tsx
+++ b/client/src/components/atoms/button/CreateButton/CreateButton.stories.tsx
@@ -7,7 +7,7 @@ export default {
 };
 
 export const createButton = (): JSX.Element => {
-  return <CreateButton onClick={() => {}} />;
+  return <CreateButton onClick={undefined} />;
 };
 
 createButton.story = {

--- a/client/src/components/atoms/div/RoundShortChips/RoundShortChips.stories.tsx
+++ b/client/src/components/atoms/div/RoundShortChips/RoundShortChips.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import RoundShortChips from './RoundShortChips';
+
+export default {
+  title: 'Atoms/Div/RoundShortChips',
+  component: RoundShortChips,
+};
+
+export const roundShortChips = (): JSX.Element => {
+  return <RoundShortChips>검색</RoundShortChips>;
+};
+
+roundShortChips.story = {
+  name: 'RoundShortChips',
+};

--- a/client/src/components/atoms/div/RoundShortChips/RoundShortChips.stories.tsx
+++ b/client/src/components/atoms/div/RoundShortChips/RoundShortChips.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import RoundShortChips from './RoundShortChips';
 
 export default {
-  title: 'Atoms/Div/RoundShortChips',
+  title: 'Atoms/div/RoundShortChips',
   component: RoundShortChips,
 };
 

--- a/client/src/components/atoms/div/RoundShortChips/RoundShortChips.tsx
+++ b/client/src/components/atoms/div/RoundShortChips/RoundShortChips.tsx
@@ -9,11 +9,17 @@ interface Props extends ChipsProps {
 interface ChipsProps {
   backgroundColor?: string;
   color?: string;
+  width?: string;
+  height?: string;
+  fontSize?: stirng;
 }
 
 const defaultProps = {
   backgroundColor: myColor.primary.accent,
   color: myColor.primary.white,
+  width: '4rem',
+  height: '1.5rem',
+  fontSize: '0.8rem',
 };
 
 const Chips = styled.div<ChipsProps>`
@@ -21,17 +27,30 @@ const Chips = styled.div<ChipsProps>`
   flex-flow: column;
   justify-content: center;
   text-align: center;
-  font-size: 0.8rem;
-  width: 4rem;
-  height: 1.5rem;
+  font-size: ${(props) => props.fontSize};
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
   background-color: ${(props) => props.backgroundColor};
   color: ${(props) => props.color};
   border-radius: 10px;
 `;
 
-const RoundShortChips: React.FC<Props> = ({ backgroundColor, color, children }: Props) => {
+const RoundShortChips: React.FC<Props> = ({
+  backgroundColor,
+  width,
+  height,
+  fontSize,
+  color,
+  children,
+}: Props) => {
   return (
-    <Chips backgroundColor={backgroundColor} color={color}>
+    <Chips
+      backgroundColor={backgroundColor}
+      width={width}
+      height={height}
+      fontSize={fontSize}
+      color={color}
+    >
       {children}
     </Chips>
   );

--- a/client/src/components/atoms/div/RoundShortChips/RoundShortChips.tsx
+++ b/client/src/components/atoms/div/RoundShortChips/RoundShortChips.tsx
@@ -12,7 +12,7 @@ interface ChipsProps {
 }
 
 const defaultProps = {
-  backgroundColor: myColor.primary.blue,
+  backgroundColor: myColor.primary.accent,
   color: myColor.primary.white,
 };
 

--- a/client/src/components/atoms/div/RoundShortChips/RoundShortChips.tsx
+++ b/client/src/components/atoms/div/RoundShortChips/RoundShortChips.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+import myColor from '@theme/color';
+
+interface Props extends ChipsProps {
+  children: React.ReactChild;
+}
+
+interface ChipsProps {
+  backgroundColor?: string;
+  color?: string;
+}
+
+const defaultProps = {
+  backgroundColor: myColor.primary.blue,
+  color: myColor.primary.white,
+};
+
+const Chips = styled.div<ChipsProps>`
+  display: flex;
+  flex-flow: column;
+  justify-content: center;
+  text-align: center;
+  font-size: 0.8rem;
+  width: 4rem;
+  height: 1.5rem;
+  background-color: ${(props) => props.backgroundColor};
+  color: ${(props) => props.color};
+  border-radius: 10px;
+`;
+
+const RoundShortChips: React.FC<Props> = ({ backgroundColor, color, children }: Props) => {
+  return (
+    <Chips backgroundColor={backgroundColor} color={color}>
+      {children}
+    </Chips>
+  );
+};
+
+RoundShortChips.defaultProps = defaultProps;
+
+export default RoundShortChips;

--- a/client/src/components/atoms/div/RoundShortChips/index.ts
+++ b/client/src/components/atoms/div/RoundShortChips/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RoundShortChips';

--- a/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.stories.tsx
+++ b/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SquircleShortChips from './SquircleShortChips';
 
 export default {
-  title: 'Atoms/Div/SquircleShortChips',
+  title: 'Atoms/div/SquircleShortChips',
   component: SquircleShortChips,
 };
 

--- a/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.stories.tsx
+++ b/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import SquircleShortChips from './SquircleShortChips';
+
+export default {
+  title: 'Atoms/Div/SquircleShortChips',
+  component: SquircleShortChips,
+};
+
+export const squircleShortChips = (): JSX.Element => {
+  return <SquircleShortChips>초대하기</SquircleShortChips>;
+};
+
+squircleShortChips.story = {
+  name: 'SquircleShortChips',
+};

--- a/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.tsx
+++ b/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.tsx
@@ -12,7 +12,7 @@ interface ChipsProps {
 }
 
 const defaultProps = {
-  color: myColor.primary.blue,
+  color: myColor.primary.accent,
   backgroundColor: myColor.primary.lightGray,
 };
 

--- a/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.tsx
+++ b/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.tsx
@@ -22,7 +22,6 @@ const Chips = styled.div<ChipsProps>`
   justify-content: center;
   text-align: center;
   font-size: 0.3rem;
-  font-weight: bold;
   width: 3rem;
   height: 1rem;
   background-color: ${(props) => props.backgroundColor};

--- a/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.tsx
+++ b/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.tsx
@@ -9,11 +9,17 @@ interface Props extends ChipsProps {
 interface ChipsProps {
   backgroundColor?: string;
   color?: string;
+  width?: string;
+  height?: string;
+  fontSize?: string;
 }
 
 const defaultProps = {
   color: myColor.primary.accent,
   backgroundColor: myColor.primary.lightGray,
+  width: '3rem',
+  height: '1.2rem',
+  fontSize: '0.3rem',
 };
 
 const Chips = styled.div<ChipsProps>`
@@ -21,17 +27,30 @@ const Chips = styled.div<ChipsProps>`
   flex-flow: column;
   justify-content: center;
   text-align: center;
-  font-size: 0.3rem;
-  width: 3rem;
-  height: 1.2rem;
+  font-size: ${(props) => props.fontSize};
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
   background-color: ${(props) => props.backgroundColor};
   color: ${(props) => props.color};
   border-radius: 3px;
 `;
 
-const SquircleShortChips: React.FC<Props> = ({ backgroundColor, color, children }: Props) => {
+const SquircleShortChips: React.FC<Props> = ({
+  backgroundColor,
+  width,
+  height,
+  fontSize,
+  color,
+  children,
+}: Props) => {
   return (
-    <Chips backgroundColor={backgroundColor} color={color}>
+    <Chips
+      backgroundColor={backgroundColor}
+      width={width}
+      height={height}
+      fontSize={fontSize}
+      color={color}
+    >
       {children}
     </Chips>
   );

--- a/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.tsx
+++ b/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled from 'styled-components';
+import myColor from '@theme/color';
+
+interface Props extends ChipsProps {
+  children: React.ReactChild;
+}
+
+interface ChipsProps {
+  backgroundColor?: string;
+  color?: string;
+}
+
+const defaultProps = {
+  color: myColor.primary.blue,
+  backgroundColor: myColor.primary.lightGray,
+};
+
+const Chips = styled.div<ChipsProps>`
+  display: flex;
+  flex-flow: column;
+  justify-content: center;
+  text-align: center;
+  font-size: 0.3rem;
+  font-weight: bold;
+  width: 3rem;
+  height: 1rem;
+  background-color: ${(props) => props.backgroundColor};
+  color: ${(props) => props.color};
+  border-radius: 3px;
+`;
+
+const SquircleShortChips: React.FC<Props> = ({ backgroundColor, color, children }: Props) => {
+  return (
+    <Chips backgroundColor={backgroundColor} color={color}>
+      {children}
+    </Chips>
+  );
+};
+
+SquircleShortChips.defaultProps = defaultProps;
+
+export default SquircleShortChips;

--- a/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.tsx
+++ b/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.tsx
@@ -23,7 +23,7 @@ const Chips = styled.div<ChipsProps>`
   text-align: center;
   font-size: 0.3rem;
   width: 3rem;
-  height: 1rem;
+  height: 1.2rem;
   background-color: ${(props) => props.backgroundColor};
   color: ${(props) => props.color};
   border-radius: 3px;

--- a/client/src/components/atoms/div/SquircleShortChips/index.ts
+++ b/client/src/components/atoms/div/SquircleShortChips/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SquircleShortChips';

--- a/client/src/theme/color.ts
+++ b/client/src/theme/color.ts
@@ -17,7 +17,6 @@ const myColor: Colors = {
     lightGray: '#EEEEEE',
     kakaoBlack: '#2F2E2D',
     brown: '#7A5A00',
-    blue: '#647FFD',
     white: '#FFFFFF',
   },
   money: {

--- a/client/src/theme/color.ts
+++ b/client/src/theme/color.ts
@@ -18,6 +18,7 @@ const myColor: Colors = {
     kakaoBlack: '#2F2E2D',
     brown: '#7A5A00',
     blue: '#647FFD',
+    white: '#FFFFFF',
   },
   money: {
     expenditure: '#7392FF',

--- a/client/src/theme/color.ts
+++ b/client/src/theme/color.ts
@@ -17,6 +17,7 @@ const myColor: Colors = {
     lightGray: '#EEEEEE',
     kakaoBlack: '#2F2E2D',
     brown: '#7A5A00',
+    blue: '#647FFD',
   },
   money: {
     expenditure: '#7392FF',


### PR DESCRIPTION
### 📕 Issue Number

related issue #5 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

#### `@theme/color` 색상 추가
  - white: `#FFFFFF`

#### `RoundShortChips` 생성  
<img width="94" alt="스크린샷 2020-11-25 오후 3 49 44" src="https://user-images.githubusercontent.com/55074799/100192751-da77f980-2f35-11eb-80a4-4f6d5ec6f5a9.png">

| props | type | default value | essential |
| --- | --- | --- | --- |
| color | string | color.primary.white | X |
| background-color | string | color.primary.blue | X | 

#### `SquircleShortChips` 생성
<img width="69" alt="스크린샷 2020-11-25 오후 3 49 54" src="https://user-images.githubusercontent.com/55074799/100192767-df3cad80-2f35-11eb-990d-7d1c7a2a806a.png">

| props | type | default value | essential |
| --- | --- | --- | --- |
| color | string | color.primary.blue | X |
| background-color | string | color.primary.lightGray | X |

<br/>

### 📘 작업 유형
- 신규 기능 추가

<br/>
