### PR TITLE
FE-feat-InputMenu

### DIFF
--- a/client/src/components/atoms/input/DropdownMenu/DropdownMenu.stories.tsx
+++ b/client/src/components/atoms/input/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import DropdownMenu from './DropdownMenu';
+
+export default {
+  title: 'Atoms/input/DropdownMenu',
+  component: DropdownMenu,
+};
+
+export const dropdownMenu = (): JSX.Element => {
+  return <DropdownMenu options={['직장인', '학생']} />;
+};
+
+dropdownMenu.story = {
+  name: 'DropdownMenu',
+};

--- a/client/src/components/atoms/input/DropdownMenu/DropdownMenu.tsx
+++ b/client/src/components/atoms/input/DropdownMenu/DropdownMenu.tsx
@@ -32,6 +32,7 @@ const Select = styled.select<selectProps>`
   border-top: none;
   border-left: none;
   border-right: none;
+  border-color: ${myColor.primary.darkGray};
   cursor: pointer;
   :hover {
     border-color: ${myColor.primary.accent};

--- a/client/src/components/atoms/input/DropdownMenu/DropdownMenu.tsx
+++ b/client/src/components/atoms/input/DropdownMenu/DropdownMenu.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import styled from 'styled-components';
+import myColor from '@theme/color';
+
+interface Props extends selectProps, optionProps {
+  options: Array<string>;
+}
+
+interface selectProps {
+  color?: string;
+  width?: string;
+  height?: string;
+  fontSize?: string;
+}
+
+interface optionProps {}
+
+const defaultProps = {
+  color: myColor.primary.black,
+  width: '8rem',
+  height: '1.2rem',
+  fontSize: '0.8rem',
+};
+
+const Select = styled.select<selectProps>`
+  font-size: ${(props) => props.fontSize};
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
+  background-color: transparent;
+  color: ${(props) => props.color};
+  border: 0.15rem solid;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  cursor: pointer;
+  :hover {
+    border-color: ${myColor.primary.accent};
+    transition: all ease 0.3s;
+  }
+  :focus {
+    border-color: ${myColor.primary.accent};
+    outline: none;
+  }
+`;
+
+const Option = styled.option<optionProps>``;
+
+const getOptionList = (options: Array<string>) =>
+  options.map((value) => <Option value={value}>{value}</Option>);
+
+const RoundShortChips: React.FC<Props> = ({ width, height, fontSize, color, options }: Props) => {
+  const optionList = getOptionList(options);
+
+  return (
+    <Select width={width} height={height} fontSize={fontSize} color={color}>
+      <Option value="">선택안함</Option>
+      {optionList}
+    </Select>
+  );
+};
+
+RoundShortChips.defaultProps = defaultProps;
+
+export default RoundShortChips;

--- a/client/src/components/atoms/input/DropdownMenu/index.ts
+++ b/client/src/components/atoms/input/DropdownMenu/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DropdownMenu';

--- a/client/src/components/atoms/input/Input/Input.stories.tsx
+++ b/client/src/components/atoms/input/Input/Input.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Input from './Input';
+
+export default {
+  title: 'Atoms/input/Input',
+  component: Input,
+};
+
+export const input = (): JSX.Element => {
+  return <Input />;
+};
+
+input.story = {
+  name: 'Input',
+};

--- a/client/src/components/atoms/input/Input/Input.tsx
+++ b/client/src/components/atoms/input/Input/Input.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+import myColor from '@theme/color';
+
+interface Props {
+  color?: string;
+  width?: string;
+  height?: string;
+  fontSize?: string;
+}
+
+const defaultProps = {
+  color: myColor.primary.black,
+  width: '8rem',
+  height: '1rem',
+  fontSize: '0.8rem',
+};
+
+const Input = styled.input<Props>`
+  font-size: ${(props) => props.fontSize};
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
+  background-color: transparent;
+  color: ${(props) => props.color};
+  border: 0.15rem solid;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  text-align: right;
+  pointer: cursor;
+  :hover {
+    border-color: ${myColor.primary.accent};
+    transition: all ease 0.3s;
+  }
+  :focus {
+    border-color: ${myColor.primary.accent};
+    outline: none;
+  }
+`;
+
+const RoundShortChips: React.FC<Props> = ({ width, height, fontSize, color }: Props) => {
+  return <Input width={width} height={height} fontSize={fontSize} color={color} />;
+};
+
+RoundShortChips.defaultProps = defaultProps;
+
+export default RoundShortChips;

--- a/client/src/components/atoms/input/Input/Input.tsx
+++ b/client/src/components/atoms/input/Input/Input.tsx
@@ -27,7 +27,7 @@ const Input = styled.input<Props>`
   border-left: none;
   border-right: none;
   text-align: right;
-  pointer: cursor;
+  cursor: pointer;
   :hover {
     border-color: ${myColor.primary.accent};
     transition: all ease 0.3s;

--- a/client/src/components/atoms/input/Input/Input.tsx
+++ b/client/src/components/atoms/input/Input/Input.tsx
@@ -23,6 +23,7 @@ const Input = styled.input<Props>`
   background-color: transparent;
   color: ${(props) => props.color};
   border: 0.15rem solid;
+  border-color: ${myColor.primary.darkGray};
   border-top: none;
   border-left: none;
   border-right: none;

--- a/client/src/components/atoms/input/Input/index.ts
+++ b/client/src/components/atoms/input/Input/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Input';


### PR DESCRIPTION
### 📕 Issue Number
Close #5 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- Input 컴포넌트 생성
<img width="405" alt="스크린샷 2020-11-26 오후 5 33 38" src="https://user-images.githubusercontent.com/55074799/100326619-86d8df00-300d-11eb-92c3-2cc29688bbfd.png">

- DropdownMenu 컴포넌트 생성
<img width="401" alt="스크린샷 2020-11-26 오후 5 33 15" src="https://user-images.githubusercontent.com/55074799/100326567-788ac300-300d-11eb-8aae-7d660741a043.png">
<img width="402" alt="스크린샷 2020-11-26 오후 5 34 28" src="https://user-images.githubusercontent.com/55074799/100326706-a4a64400-300d-11eb-9070-417eababa0aa.png">

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- DropdownMenu 컴포넌트를 생성시, map 객체를 활용하여 내부의 Option 컴포넌트를 반복적으로 생성합니다

<br/><br/>