### PR TITLE
BE-feat naver OAuth API 구현

### DIFF
--- a/server/src/interface/index.ts
+++ b/server/src/interface/index.ts
@@ -5,7 +5,7 @@ interface oauthOption {
 }
 
 interface oauthUserData {
-  login: string;
+  name: string;
   id: string;
 }
 

--- a/server/src/oauth/controller.ts
+++ b/server/src/oauth/controller.ts
@@ -34,7 +34,9 @@ const naver = async (ctx: Context) => {
     },
   };
   const token = await Service.getAccessTokenNaver(process.env.NAVER_TOKEN_URL as string, option);
-  const data = await Service.getUserData(token);
+
+  const data = await Service.getOAuthUserDataNaver(process.env.NAVER_USER_URL as string, token);
+
   console.log(data);
 };
 

--- a/server/src/oauth/controller.ts
+++ b/server/src/oauth/controller.ts
@@ -14,7 +14,7 @@ const github = async (ctx: Context) => {
 
   const token = await Service.getAccessToken(process.env.GITHUB_TOKEN_URL as string, option);
 
-  const data = await Service.getOauthUserData(process.env.GITHUB_USER_URL as string, token);
+  const data = await Service.getOAuthUserData(process.env.GITHUB_USER_URL as string, token);
 
   const jwtToken = Service.createJWTtoken(data);
 
@@ -22,4 +22,20 @@ const github = async (ctx: Context) => {
   ctx.redirect(process.env.LOGIN_SUCCESS_URL as string);
 };
 
-export { github };
+const naver = async (ctx: Context) => {
+  const { code } = ctx.query;
+  const option = {
+    params: {
+      code,
+      grant_type: 'authorization_code' as string,
+      client_id: process.env.NAVER_CLIENT_ID as string,
+      client_secret: process.env.NAVER_CLIENT_SECRET as string,
+      state: 'abc' as string,
+    },
+  };
+  const token = await Service.getAccessTokenNaver(process.env.NAVER_TOKEN_URL as string, option);
+  const data = await Service.getUserData(token);
+  console.log(data);
+};
+
+export { github, naver };

--- a/server/src/oauth/controller.ts
+++ b/server/src/oauth/controller.ts
@@ -27,17 +27,20 @@ const naver = async (ctx: Context) => {
   const option = {
     params: {
       code,
-      grant_type: 'authorization_code' as string,
+      grant_type: 'authorization_code',
       client_id: process.env.NAVER_CLIENT_ID as string,
       client_secret: process.env.NAVER_CLIENT_SECRET as string,
-      state: 'abc' as string,
+      state: 'abc',
     },
   };
   const token = await Service.getAccessTokenNaver(process.env.NAVER_TOKEN_URL as string, option);
 
   const data = await Service.getOAuthUserDataNaver(process.env.NAVER_USER_URL as string, token);
 
-  console.log(data);
+  const jwtToken = Service.createJWTtoken(data);
+
+  ctx.cookies.set('jwt', jwtToken);
+  ctx.redirect(process.env.LOGIN_SUCCESS_URL as string);
 };
 
 export { github, naver };

--- a/server/src/oauth/router.ts
+++ b/server/src/oauth/router.ts
@@ -4,6 +4,8 @@ const Router = require('@koa/router');
 
 const router = new Router();
 
-router.get('/callback/github', Controller.github);
+// router.get('/callback/github', Controller.github);
+
+router.get('/callback/login', Controller.naver);
 
 export default router;

--- a/server/src/oauth/router.ts
+++ b/server/src/oauth/router.ts
@@ -4,8 +4,10 @@ const Router = require('@koa/router');
 
 const router = new Router();
 
-// router.get('/callback/github', Controller.github);
+router.get('/callback/github', Controller.github);
 
 router.get('/callback/login', Controller.naver);
+
+// router.get('/callback/login?site=github or naver', ...)
 
 export default router;

--- a/server/src/oauth/service.ts
+++ b/server/src/oauth/service.ts
@@ -31,7 +31,7 @@ const createJWTtoken = (data: Interface.oauthUserData) => {
 };
 
 const getAccessTokenNaver = async (url: string, option: any) => {
-  const response = await axios.get('https://nid.naver.com/oauth2.0/token', option, {
+  const response = await axios.get(url, option, {
     headers: {
       accept: 'application/json',
     },
@@ -39,8 +39,8 @@ const getAccessTokenNaver = async (url: string, option: any) => {
   return response.data.access_token;
 };
 
-const getUserData = async (token: string) => {
-  const { data } = await axios.get(`https://openapi.naver.com/v1/nid/me`, {
+const getOAuthUserDataNaver = async (url: string, token: string) => {
+  const { data } = await axios.get(url, {
     headers: {
       Authorization: `Bearer ${token}`,
     },
@@ -48,4 +48,10 @@ const getUserData = async (token: string) => {
   return data.response;
 };
 
-export { getAccessToken, getOAuthUserData, createJWTtoken, getAccessTokenNaver, getUserData };
+export {
+  getAccessToken,
+  getOAuthUserData,
+  createJWTtoken,
+  getAccessTokenNaver,
+  getOAuthUserDataNaver,
+};

--- a/server/src/oauth/service.ts
+++ b/server/src/oauth/service.ts
@@ -24,7 +24,7 @@ const getOAuthUserData = async (url: string, token: string) => {
 };
 
 const createJWTtoken = (data: Interface.oauthUserData) => {
-  const jwtToken = jwt.sign({ login: data.login, id: data.id }, process.env.JWT_SECRET, {
+  const jwtToken = jwt.sign({ login: data.name, id: data.id }, process.env.JWT_SECRET, {
     expiresIn: '1d',
   });
   return jwtToken;

--- a/server/src/oauth/service.ts
+++ b/server/src/oauth/service.ts
@@ -14,7 +14,7 @@ const getAccessToken = async (url: string, option: Interface.oauthOption) => {
   return token;
 };
 
-const getOauthUserData = async (url: string, token: string) => {
+const getOAuthUserData = async (url: string, token: string) => {
   const { data } = await axios.get(url, {
     headers: {
       Authorization: `token ${token}`,
@@ -30,4 +30,22 @@ const createJWTtoken = (data: Interface.oauthUserData) => {
   return jwtToken;
 };
 
-export { getAccessToken, getOauthUserData, createJWTtoken };
+const getAccessTokenNaver = async (url: string, option: any) => {
+  const response = await axios.get('https://nid.naver.com/oauth2.0/token', option, {
+    headers: {
+      accept: 'application/json',
+    },
+  });
+  return response.data.access_token;
+};
+
+const getUserData = async (token: string) => {
+  const { data } = await axios.get(`https://openapi.naver.com/v1/nid/me`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return data.response;
+};
+
+export { getAccessToken, getOAuthUserData, createJWTtoken, getAccessTokenNaver, getUserData };


### PR DESCRIPTION
### 📕 Issue Number

Close #4 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- Naver OAuth API 구현
- Access Token 요청함수 구현
    - code, grant_type: `authorization_code`, client_id, client_secret, state
      필요
- User Data 요청함수 구현
    - 요청 헤더에 Authorization: `Bearer ${token}` 로 설정해야 함

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 추후에 리팩토링을 위해 callback url 에 쿼리설정 8000:callback/login?site=naver
- getAccessTokenNaver 함수에서 axios 요청시 post로 보내면 쿼리에 파라미터가 포함이 안되는 이슈 발생 -> get 으로 처리 (github 요청과 옵션의 형태가 다름)  

<br/><br/>