### PR TITLE
FE-feat-createAccountbookPage & 콜리타임

### DIFF
--- a/client/config/env.js
+++ b/client/config/env.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const fs = require('fs');
 const path = require('path');
 const paths = require('./paths');
@@ -7,11 +5,9 @@ const paths = require('./paths');
 // Make sure that including paths.js after env.js will read .env variables.
 delete require.cache[require.resolve('./paths')];
 
-const NODE_ENV = process.env.NODE_ENV;
+const { NODE_ENV } = process.env;
 if (!NODE_ENV) {
-  throw new Error(
-    'The NODE_ENV environment variable is required but was not specified.'
-  );
+  throw new Error('The NODE_ENV environment variable is required but was not specified.');
 }
 
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
@@ -30,12 +26,12 @@ const dotenvFiles = [
 // that have already been set.  Variable expansion is supported in .env files.
 // https://github.com/motdotla/dotenv
 // https://github.com/motdotla/dotenv-expand
-dotenvFiles.forEach(dotenvFile => {
+dotenvFiles.forEach((dotenvFile) => {
   if (fs.existsSync(dotenvFile)) {
     require('dotenv-expand')(
       require('dotenv').config({
         path: dotenvFile,
-      })
+      }),
     );
   }
 });
@@ -52,8 +48,8 @@ dotenvFiles.forEach(dotenvFile => {
 const appDirectory = fs.realpathSync(process.cwd());
 process.env.NODE_PATH = (process.env.NODE_PATH || '')
   .split(path.delimiter)
-  .filter(folder => folder && !path.isAbsolute(folder))
-  .map(folder => path.resolve(appDirectory, folder))
+  .filter((folder) => folder && !path.isAbsolute(folder))
+  .map((folder) => path.resolve(appDirectory, folder))
   .join(path.delimiter);
 
 // Grab NODE_ENV and REACT_APP_* environment variables and prepare them to be
@@ -62,7 +58,7 @@ const REACT_APP = /^REACT_APP_/i;
 
 function getClientEnvironment(publicUrl) {
   const raw = Object.keys(process.env)
-    .filter(key => REACT_APP.test(key))
+    .filter((key) => REACT_APP.test(key))
     .reduce(
       (env, key) => {
         env[key] = process.env[key];
@@ -90,7 +86,7 @@ function getClientEnvironment(publicUrl) {
         // which is why it's disabled by default.
         // It is defined here so it is available in the webpackHotDevClient.
         FAST_REFRESH: process.env.FAST_REFRESH !== 'false',
-      }
+      },
     );
   // Stringify all values so we can feed into webpack DefinePlugin
   const stringified = {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import LoginPage from '@views/LoginPage';
 import MainPage from '@views/MainPage';
 import NotificationPage from '@views/NotificationPage';
 import MyPage from '@views/MyPage';
+import CreateAccountbookPage from '@views/CreateAccountbookPage';
 import GlobalStyle from '@shared/global';
 import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 
@@ -14,6 +15,7 @@ const App: React.FC = () => {
         <Route path="/login" component={LoginPage} />
         <Route path="/notification" component={NotificationPage} />
         <Route path="/mypage" component={MyPage} />
+        <Route path="/createAccountbook" component={CreateAccountbookPage} />
         <Redirect from="*" to="/" />
       </Switch>
     </>

--- a/client/src/components/atoms/button/CircleIconButton/CircleIconButton.stories.tsx
+++ b/client/src/components/atoms/button/CircleIconButton/CircleIconButton.stories.tsx
@@ -3,19 +3,25 @@ import Color from '@theme/color';
 import Pencil from '@svg/pencil.svg';
 import CircleIconButton from './CircleIconButton';
 
+interface Props {
+  backgroundColor: string;
+}
+
 export default {
   title: 'Atoms/button/CircleIconButton',
   component: CircleIconButton,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
 };
 
 const onClick = (): boolean => {
   return true;
 };
 
-export const circleIconButton = (): JSX.Element => {
-  const backgroundColor = Color.primary.lightGray;
+export const circleIconButton = ({ ...args }: Props): JSX.Element => {
   return (
-    <CircleIconButton backgroundColor={backgroundColor} onClick={onClick}>
+    <CircleIconButton {...args} onClick={onClick}>
       {Pencil}
     </CircleIconButton>
   );
@@ -23,4 +29,8 @@ export const circleIconButton = (): JSX.Element => {
 
 circleIconButton.story = {
   name: 'CircleIconButton',
+};
+
+circleIconButton.args = {
+  backgroundColor: Color.primary.lightGray,
 };

--- a/client/src/components/atoms/button/OAuthButton/OAuthButton.stories.tsx
+++ b/client/src/components/atoms/button/OAuthButton/OAuthButton.stories.tsx
@@ -4,34 +4,43 @@ import OAuthButton from './OAuthButton';
 export default {
   title: 'Atoms/button/OAuthButton',
   component: OAuthButton,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+    link: { control: 'text' },
+    site: { control: 'text' },
+  },
 };
 
-export const githubButton = (): JSX.Element => {
-  const link = 'https://github.com/';
-  const oauthSite = 'GitHub';
-  const backgroundColor = '#444444';
-  return (
-    <OAuthButton site={oauthSite} backgroundColor={backgroundColor} link={link}>
-      깃허브 계정으로 로그인
-    </OAuthButton>
-  );
+interface Props {
+  backgroundColor: string;
+  link: string;
+  site: string;
+}
+
+export const githubButton = ({ ...args }: Props): JSX.Element => {
+  return <OAuthButton {...args}>깃허브 계정으로 로그인</OAuthButton>;
 };
 
-export const naverButton = (): JSX.Element => {
-  const link = 'https://www.naver.com/';
-  const oauthSite = 'Naver';
-  const backgroundColor = '#4fa42b';
-  return (
-    <OAuthButton site={oauthSite} backgroundColor={backgroundColor} link={link}>
-      네이버 계정으로 로그인
-    </OAuthButton>
-  );
+export const naverButton = ({ ...args }: Props): JSX.Element => {
+  return <OAuthButton {...args}>네이버 계정으로 로그인</OAuthButton>;
 };
 
 githubButton.story = {
   name: 'gitHubButton',
 };
 
+githubButton.args = {
+  backgroundColor: '#444444',
+  link: 'https://github.com/',
+  site: 'GitHub',
+};
+
 naverButton.story = {
   name: 'naverButton',
+};
+
+naverButton.args = {
+  backgroundColor: '#4fa42b',
+  link: 'https://www.naver.com/',
+  site: 'Naver',
 };

--- a/client/src/components/atoms/checkbox/CheckBox/CheckBox.stories.tsx
+++ b/client/src/components/atoms/checkbox/CheckBox/CheckBox.stories.tsx
@@ -5,40 +5,41 @@ import CheckBox from './CheckBox';
 export default {
   title: 'Atoms/checkbox',
   component: CheckBox,
+  argTypes: {
+    color: { control: 'color' },
+    description: { control: 'text' },
+  },
 };
 
-export const expenditureCheckBox = (): JSX.Element => {
+interface Props {
+  color: string;
+  description: string;
+}
+
+export const expenditureCheckBox = ({ ...args }: Props): JSX.Element => {
   const [check, setCheck] = useState(false);
-  const color = Color.money.expenditure;
-  const description = '지출';
-  return (
-    <CheckBox
-      checked={check}
-      color={color}
-      description={description}
-      onClick={() => setCheck(!check)}
-    />
-  );
+  return <CheckBox checked={check} {...args} onClick={() => setCheck(!check)} />;
 };
 
-export const incomeCheckBox = (): JSX.Element => {
+export const incomeCheckBox = ({ ...args }: Props): JSX.Element => {
   const [check, setCheck] = useState(false);
-  const color = Color.money.income;
-  const description = '수입';
-  return (
-    <CheckBox
-      checked={check}
-      color={color}
-      description={description}
-      onClick={() => setCheck(!check)}
-    />
-  );
+  return <CheckBox checked={check} {...args} onClick={() => setCheck(!check)} />;
 };
 
 expenditureCheckBox.story = {
   name: 'expenditureCheckBox',
 };
 
+expenditureCheckBox.args = {
+  color: Color.money.expenditure,
+  description: '지출',
+};
+
 incomeCheckBox.story = {
   name: 'incomeCheckBox',
+};
+
+incomeCheckBox.args = {
+  color: Color.money.income,
+  description: '수입',
 };

--- a/client/src/components/atoms/div/ColorLabel/ColorLabel.stories.tsx
+++ b/client/src/components/atoms/div/ColorLabel/ColorLabel.stories.tsx
@@ -12,6 +12,7 @@ export default {
   component: ColorLabel,
   argTypes: {
     backgroundColor: { control: 'color' },
+    size: { control: 'text' },
   },
 };
 

--- a/client/src/components/atoms/div/RoundShortChips/RoundShortChips.stories.tsx
+++ b/client/src/components/atoms/div/RoundShortChips/RoundShortChips.stories.tsx
@@ -1,15 +1,39 @@
 import React from 'react';
+import myColor from '@theme/color';
 import RoundShortChips from './RoundShortChips';
+
+interface Props {
+  backgroundColor?: string;
+  color?: string;
+  width?: string;
+  height?: string;
+  fontSize?: string;
+}
 
 export default {
   title: 'Atoms/div/RoundShortChips',
   component: RoundShortChips,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+    color: { control: 'color' },
+    width: { control: 'text' },
+    height: { control: 'text' },
+    fontSize: { control: 'text' },
+  },
 };
 
-export const roundShortChips = (): JSX.Element => {
-  return <RoundShortChips>검색</RoundShortChips>;
+export const roundShortChips = ({ ...args }: Props): JSX.Element => {
+  return <RoundShortChips {...args}>검색</RoundShortChips>;
 };
 
 roundShortChips.story = {
   name: 'RoundShortChips',
+};
+
+roundShortChips.args = {
+  backgroundColor: myColor.primary.accent,
+  color: myColor.primary.white,
+  width: '4rem',
+  height: '1.5rem',
+  fontSize: '0.8rem',
 };

--- a/client/src/components/atoms/div/SquircleCard/SquircleCard.stories.tsx
+++ b/client/src/components/atoms/div/SquircleCard/SquircleCard.stories.tsx
@@ -1,15 +1,36 @@
 import React from 'react';
+import myColor from '@theme/color';
 import SquircleCard from './SquircleCard';
+
+interface Props {
+  backgroundColor?: string;
+  width?: string;
+  height?: string;
+  flexFlow?: string;
+}
 
 export default {
   title: 'Atoms/div/SquircleCard',
   component: SquircleCard,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+    width: { control: 'text' },
+    height: { control: 'text' },
+    flexFlow: { control: 'text' },
+  },
 };
 
-export const squircleCard = (): JSX.Element => {
-  return <SquircleCard>SquircleCard</SquircleCard>;
+export const squircleCard = ({ ...args }: Props): JSX.Element => {
+  return <SquircleCard {...args}>SquircleCard</SquircleCard>;
 };
 
 squircleCard.story = {
   name: 'SquircleCard',
+};
+
+squircleCard.args = {
+  backgroundColor: myColor.primary.main,
+  width: '500px',
+  height: '120px',
+  flexFlow: 'row',
 };

--- a/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.stories.tsx
+++ b/client/src/components/atoms/div/SquircleShortChips/SquircleShortChips.stories.tsx
@@ -1,15 +1,39 @@
 import React from 'react';
+import myColor from '@theme/color';
 import SquircleShortChips from './SquircleShortChips';
+
+interface Props {
+  backgroundColor?: string;
+  color?: string;
+  width?: string;
+  height?: string;
+  fontSize?: string;
+}
 
 export default {
   title: 'Atoms/div/SquircleShortChips',
   component: SquircleShortChips,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+    color: { control: 'color' },
+    width: { control: 'text' },
+    height: { control: 'text' },
+    fontSize: { control: 'text' },
+  },
 };
 
-export const squircleShortChips = (): JSX.Element => {
-  return <SquircleShortChips>초대하기</SquircleShortChips>;
+export const squircleShortChips = ({ ...args }: Props): JSX.Element => {
+  return <SquircleShortChips {...args}>초대하기</SquircleShortChips>;
 };
 
 squircleShortChips.story = {
   name: 'SquircleShortChips',
+};
+
+squircleShortChips.args = {
+  backgroundColor: myColor.primary.lightGray,
+  color: myColor.primary.accent,
+  width: '3rem',
+  height: '1.2rem',
+  fontSize: '0.3rem',
 };

--- a/client/src/components/atoms/hr/Line/Line.stories.tsx
+++ b/client/src/components/atoms/hr/Line/Line.stories.tsx
@@ -1,16 +1,30 @@
 import React from 'react';
+import myColor from '@theme/color';
 import Line from './Line';
+
+interface Props {
+  lineColor?: string;
+  widthPercent?: number;
+}
 
 export default {
   title: 'Atoms/hr/Line',
   component: Line,
+  argTypes: {
+    lineColor: { control: 'color' },
+    widthPercent: { control: 'number' },
+  },
 };
 
-export const iconButton = (): JSX.Element => {
-  const widthPercent = 50;
-  return <Line widthPercent={widthPercent} />;
+export const iconButton = ({ ...args }: Props): JSX.Element => {
+  return <Line {...args} />;
 };
 
 iconButton.story = {
   name: 'Line',
+};
+
+iconButton.args = {
+  lineColor: myColor.primary.lightGray,
+  widthPercent: 80,
 };

--- a/client/src/components/atoms/input/DropdownMenu/DropdownMenu.stories.tsx
+++ b/client/src/components/atoms/input/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,15 +1,36 @@
 import React from 'react';
+import myColor from '@theme/color';
 import DropdownMenu from './DropdownMenu';
+
+interface Props {
+  color?: string;
+  width?: string;
+  height?: string;
+  fontSize?: string;
+}
 
 export default {
   title: 'Atoms/input/DropdownMenu',
   component: DropdownMenu,
+  argTypes: {
+    color: { control: 'color' },
+    width: { control: 'text' },
+    height: { control: 'text' },
+    fontSize: { control: 'text' },
+  },
 };
 
-export const dropdownMenu = (): JSX.Element => {
-  return <DropdownMenu options={['직장인', '학생']} />;
+export const dropdownMenu = ({ ...args }: Props): JSX.Element => {
+  return <DropdownMenu {...args} options={['직장인', '학생']} />;
 };
 
 dropdownMenu.story = {
   name: 'DropdownMenu',
+};
+
+dropdownMenu.args = {
+  color: myColor.primary.black,
+  width: '8rem',
+  height: '1.2rem',
+  fontSize: '0.8rem',
 };

--- a/client/src/components/atoms/input/Input/Input.stories.tsx
+++ b/client/src/components/atoms/input/Input/Input.stories.tsx
@@ -1,15 +1,36 @@
 import React from 'react';
+import myColor from '@theme/color';
 import Input from './Input';
+
+interface Props {
+  color?: string;
+  width?: string;
+  height?: string;
+  fontSize?: string;
+}
 
 export default {
   title: 'Atoms/input/Input',
   component: Input,
+  argTypes: {
+    color: { control: 'color' },
+    width: { control: 'text' },
+    height: { control: 'text' },
+    fontSize: { control: 'text' },
+  },
 };
 
-export const input = (): JSX.Element => {
-  return <Input />;
+export const input = ({ ...args }: Props): JSX.Element => {
+  return <Input {...args} />;
 };
 
 input.story = {
   name: 'Input',
+};
+
+input.args = {
+  color: myColor.primary.black,
+  width: '8rem',
+  height: '1rem',
+  fontSize: '0.8rem',
 };

--- a/client/src/components/atoms/p/CenterLargeText/CenterLargeText.stories.tsx
+++ b/client/src/components/atoms/p/CenterLargeText/CenterLargeText.stories.tsx
@@ -1,15 +1,33 @@
 import React from 'react';
+import myColor from '@theme/color';
 import CenterLargeText from './CenterLargeText';
+
+interface Props {
+  color?: string;
+  fontSize?: string;
+  fontWeight?: string;
+}
 
 export default {
   title: 'Atoms/p/CenterLargeText',
   component: CenterLargeText,
+  argTypes: {
+    color: { control: 'color' },
+    fontSize: { control: 'text' },
+    fontWeight: { control: 'text' },
+  },
 };
 
-export const centerLargeText = (): JSX.Element => {
-  return <CenterLargeText>Sample Text</CenterLargeText>;
+export const centerLargeText = ({ ...args }: Props): JSX.Element => {
+  return <CenterLargeText {...args}>Sample Text</CenterLargeText>;
 };
 
 centerLargeText.story = {
   name: 'CenterLargeText',
+};
+
+centerLargeText.args = {
+  color: myColor.primary.black,
+  fontSize: '24px',
+  fontWeight: 'normal',
 };

--- a/client/src/components/atoms/p/CenterNormalText/CenterNormalText.stories.tsx
+++ b/client/src/components/atoms/p/CenterNormalText/CenterNormalText.stories.tsx
@@ -1,15 +1,33 @@
 import React from 'react';
+import myColor from '@theme/color';
 import CenterNormalText from './CenterNormalText';
+
+interface Props {
+  color?: string;
+  fontSize?: string;
+  fontWeight?: string;
+}
 
 export default {
   title: 'Atoms/p/CenterNormalText',
   component: CenterNormalText,
+  argTypes: {
+    color: { control: 'color' },
+    fontSize: { control: 'text' },
+    fontWeight: { control: 'text' },
+  },
 };
 
-export const centerNormalText = (): JSX.Element => {
-  return <CenterNormalText>Sample Text</CenterNormalText>;
+export const centerNormalText = ({ ...args }: Props): JSX.Element => {
+  return <CenterNormalText {...args}>Sample Text</CenterNormalText>;
 };
 
 centerNormalText.story = {
   name: 'CenterNormalText',
+};
+
+centerNormalText.args = {
+  color: myColor.primary.black,
+  fontSize: '24px',
+  fontWeight: 'normal',
 };

--- a/client/src/components/atoms/p/CenterSmallText/CenterSmallText.stories.tsx
+++ b/client/src/components/atoms/p/CenterSmallText/CenterSmallText.stories.tsx
@@ -1,15 +1,33 @@
 import React from 'react';
+import myColor from '@theme/color';
 import CenterSmallText from './CenterSmallText';
+
+interface Props {
+  color?: string;
+  fontSize?: string;
+  fontWeight?: string;
+}
 
 export default {
   title: 'Atoms/p/CenterSmallText',
   component: CenterSmallText,
+  argTypes: {
+    color: { control: 'color' },
+    fontSize: { control: 'text' },
+    fontWeight: { control: 'text' },
+  },
 };
 
-export const centerSmallText = (): JSX.Element => {
-  return <CenterSmallText>Sample Text</CenterSmallText>;
+export const centerSmallText = ({ ...args }: Props): JSX.Element => {
+  return <CenterSmallText {...args}>Sample Text</CenterSmallText>;
 };
 
 centerSmallText.story = {
   name: 'CenterSmallText',
+};
+
+centerSmallText.args = {
+  color: myColor.primary.black,
+  fontSize: '12px',
+  fontWeight: 'normal',
 };

--- a/client/src/components/atoms/textarea/TextArea/TextArea.stories.tsx
+++ b/client/src/components/atoms/textarea/TextArea/TextArea.stories.tsx
@@ -1,17 +1,29 @@
 import React from 'react';
 import TextArea from './TextArea';
 
+interface Props {
+  width: string;
+  height: string;
+}
+
 export default {
   title: 'Atoms/textarea',
   component: TextArea,
+  argTypes: {
+    width: { control: 'text' },
+    height: { control: 'text' },
+  },
 };
 
-export const textArea = (): JSX.Element => {
-  const height = '120px';
-  const width = '300px';
-  return <TextArea width={width} height={height} />;
+export const textArea = ({ ...args }: Props): JSX.Element => {
+  return <TextArea {...args} />;
 };
 
 textArea.story = {
   name: 'TextArea',
+};
+
+textArea.args = {
+  width: '300px',
+  height: '120px',
 };

--- a/client/src/components/organisms/ColoredBackground/ColoredBackground.stories.tsx
+++ b/client/src/components/organisms/ColoredBackground/ColoredBackground.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import myColor from '@theme/color';
+import ColoredBackground from './ColoredBackground';
+
+export default {
+  title: 'Organisms/ColoredBackground',
+  component: ColoredBackground,
+};
+
+export const coloredBackground = (): JSX.Element => {
+  return <ColoredBackground backgroundColor={myColor.primary.lightGray} />;
+};
+
+coloredBackground.story = {
+  name: 'ColoredBackground',
+};

--- a/client/src/components/organisms/ColoredBackground/ColoredBackground.tsx
+++ b/client/src/components/organisms/ColoredBackground/ColoredBackground.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Background from '@atoms/div/Background';
+import AccountBookBackground from '@atoms/div/AccountBookBackground';
+
+interface Props {
+  backgroundColor: string;
+}
+
+const ColoredBackground: React.FC<Props> = ({ backgroundColor }: Props) => {
+  return (
+    <Background>
+      <AccountBookBackground height="100%" backgroundColor={backgroundColor} />
+    </Background>
+  );
+};
+
+export default ColoredBackground;

--- a/client/src/components/organisms/ColoredBackground/index.ts
+++ b/client/src/components/organisms/ColoredBackground/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ColoredBackground';

--- a/client/src/views/CreateAccountbookPage.tsx
+++ b/client/src/views/CreateAccountbookPage.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import ColoredBackground from '@organisms/ColoredBackground';
+import myColor from '@theme/color';
+// import TopNavBar from '../components/organisms/TopNavBar';
+
+const CreateAccountbookPage: React.FC = () => {
+  return (
+    <>
+      <ColoredBackground backgroundColor={myColor.primary.lightGray} />
+    </>
+  );
+};
+
+/*
+<ColoredBackground backgroundColor={myColor.primary.lightGray} />
+      <CenterContent>
+        <ColumnFlexContainer>
+          <TopNavBar />
+          <CreateAccountbookForm />
+          <AccountbookSetting />
+        </ColumnFlexContainer>
+      </CenterContent>
+*/
+
+export default CreateAccountbookPage;


### PR DESCRIPTION
### 📕 Issue Number

related Issue #64 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 가계부 생성 페이지
   - 우선적으로 가계부 생성 페이지 ui 틀 작성
   - 색깔있는 배경을 사용할 수 있도록 organisms에 ColoredBackground 추가
![image](https://user-images.githubusercontent.com/61405355/100638867-ddc91600-3377-11eb-9d4a-3cdbdf071f13.png)

- 콜리타임
   - atoms 중 control 빠져있는 atom 찾아서 추가해주었음 ( 일단 p 태그는 제외 )
   예시 ) DropdownMenu
![image](https://user-images.githubusercontent.com/61405355/100639119-2254b180-3378-11eb-8a6a-3ab3283c284e.png)


<br/>

### 📘 작업 유형

- 신규 기능 추가
- 리펙토링

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 틀만 작성해서 페이지 Router만 생성해주고, page 파일에서는 일단 주석으로 틀만 잡아두었습니다.
- 우선 p 태그를 제외한 모든 atoms에 control 요소를 추가해주었습니다. p 태그는 굳이 control이 필요하지 않을 것 같아서 일단 놔뒀습니다! 

<br/><br/>