### PR TITLE
FE-feat-modal Redux를 이용한 modal 기능 구현, 마이페이지 모달 생성

### DIFF
--- a/client/.storybook/main.js
+++ b/client/.storybook/main.js
@@ -17,7 +17,7 @@ module.exports = {
     config.node = {
       fs: 'empty',
       net: 'empty',
-    }
+    };
     config.resolve.alias = {
       ...config.resolve.alias,
       '@atoms': path.resolve(__dirname, '../src/components/atoms/'),
@@ -28,6 +28,7 @@ module.exports = {
       '@utils': path.resolve(__dirname, '../src/utils/'),
       '@views': path.resolve(__dirname, '../src/views/'),
       '@reducers': path.resolve(__dirname, '../src/reducers/'),
+      '@actions': path.resolve(__dirname, '../src/actions/'),
       '@store': path.resolve(__dirname, '../src/store/'),
       '@hooks': path.resolve(__dirname, '../src/hooks/'),
       '@svg': path.resolve(__dirname, '../src/assets/svg/'),

--- a/client/.storybook/preview.js
+++ b/client/.storybook/preview.js
@@ -1,11 +1,17 @@
 import React from 'react';
 import GlobalStyle from '../src/shared/global';
+import initStore from '@store/index';
+import { Provider } from 'react-redux';
+
+const store = initStore();
 
 export const decorators = [
   (Story) => (
     <>
-      <GlobalStyle />
-      <Story />
+      <Provider store={store}>
+        <GlobalStyle />
+        <Story />
+      </Provider>
     </>
   ),
 ];

--- a/client/config/webpack.config.js
+++ b/client/config/webpack.config.js
@@ -315,6 +315,7 @@ module.exports = function (webpackEnv) {
         '@utils': path.resolve(__dirname, '../src/utils/'),
         '@views': path.resolve(__dirname, '../src/views/'),
         '@reducers': path.resolve(__dirname, '../src/reducers/'),
+        '@actions': path.resolve(__dirname, '../src/actions/'),
         '@store': path.resolve(__dirname, '../src/store/'),
         '@shared': path.resolve(__dirname, '../src/shared/'),
         '@hooks': path.resolve(__dirname, '../src/hooks/'),

--- a/client/src/actions/modal/type.ts
+++ b/client/src/actions/modal/type.ts
@@ -1,0 +1,10 @@
+export const ACCOUNTBOOK_OPEN = 'modal/ACCOUNTBOOK_OPEN' as const;
+export const ACCOUNTBOOK_CLOSE = 'modal/ACCOUNTBOOK_CLOSE' as const;
+
+export const accountbookOpen = () => ({
+  type: ACCOUNTBOOK_OPEN,
+});
+
+export const accountbookClose = () => ({
+  type: ACCOUNTBOOK_CLOSE,
+});

--- a/client/src/actions/modal/type.ts
+++ b/client/src/actions/modal/type.ts
@@ -1,10 +1,11 @@
-export const ACCOUNTBOOK_OPEN = 'modal/ACCOUNTBOOK_OPEN' as const;
-export const ACCOUNTBOOK_CLOSE = 'modal/ACCOUNTBOOK_CLOSE' as const;
+export const SHOW_MODAL = 'modal/MODAL_OPEN' as const;
+export const HIDE_MODAL = 'modal/MODAL_CLOSE' as const;
 
-export const accountbookOpen = () => ({
-  type: ACCOUNTBOOK_OPEN,
+export const showModal = (view: string) => ({
+  type: SHOW_MODAL,
+  payload: view,
 });
 
-export const accountbookClose = () => ({
-  type: ACCOUNTBOOK_CLOSE,
+export const hideModal = () => ({
+  type: HIDE_MODAL,
 });

--- a/client/src/components/atoms/button/HexagonButton/HexagonButton.tsx
+++ b/client/src/components/atoms/button/HexagonButton/HexagonButton.tsx
@@ -68,7 +68,7 @@ const ButtonName = styled.p`
   font-size: 1em;
 `;
 
-const CreateButton: React.FC<Props> = ({ size, name, color, svgIcon, onClick }: Props) => {
+const hexagonButton: React.FC<Props> = ({ size, name, color, svgIcon, onClick }: Props) => {
   return (
     <Container size={size}>
       <ButtonBackground>
@@ -83,6 +83,6 @@ const CreateButton: React.FC<Props> = ({ size, name, color, svgIcon, onClick }: 
   );
 };
 
-CreateButton.defaultProps = defaultProps;
+hexagonButton.defaultProps = defaultProps;
 
-export default CreateButton;
+export default hexagonButton;

--- a/client/src/components/molecules/Modal/Modal.tsx
+++ b/client/src/components/molecules/Modal/Modal.tsx
@@ -25,9 +25,6 @@ const defaultProps = {
 };
 
 const ModalBackground = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
   position: absolute;
   width: 100vw;
   height: 100vh;
@@ -35,7 +32,16 @@ const ModalBackground = styled.div`
   z-index: 3;
 `;
 
-const ModalContainer = styled.div<modalProps>`
+const ModalContainer = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  height: 100vh;
+`;
+
+const Modal = styled.div<modalProps>`
   max-width: 800px;
   width: ${(props) => props.width};
   height: ${(props) => props.height};
@@ -44,13 +50,14 @@ const ModalContainer = styled.div<modalProps>`
   border: 0;
   border-radius: 8px;
   padding: 10px 40px;
+  z-index: 4;
 `;
 
 const ButtonContainer = styled.div`
   margin-left: auto;
 `;
 
-const Modal: React.FC<Props> = ({ title, children, ...props }: Props) => {
+const modal: React.FC<Props> = ({ title, children, ...props }: Props) => {
   const dispatch = useDispatch();
 
   const closeModal = () => {
@@ -58,26 +65,29 @@ const Modal: React.FC<Props> = ({ title, children, ...props }: Props) => {
   };
 
   return (
-    <ModalBackground onClick={closeModal}>
-      <ModalContainer {...props}>
-        <ColumnFlexContainer>
-          <RowFlexContainer width="100%" margin="10px 0">
-            <Title>
-              <>{title}</>
-            </Title>
-            <ButtonContainer>
-              <Closed onClick={closeModal} color="black">
-                X
-              </Closed>
-            </ButtonContainer>
-          </RowFlexContainer>
-          <>{children}</>
-        </ColumnFlexContainer>
+    <>
+      <ModalBackground onClick={closeModal} />
+      <ModalContainer>
+        <Modal {...props}>
+          <ColumnFlexContainer>
+            <RowFlexContainer width="100%" margin="10px 0">
+              <Title>
+                <>{title}</>
+              </Title>
+              <ButtonContainer>
+                <Closed onClick={closeModal} color="black">
+                  X
+                </Closed>
+              </ButtonContainer>
+            </RowFlexContainer>
+            <>{children}</>
+          </ColumnFlexContainer>
+        </Modal>
       </ModalContainer>
-    </ModalBackground>
+    </>
   );
 };
 
-Modal.defaultProps = defaultProps;
+modal.defaultProps = defaultProps;
 
-export default Modal;
+export default modal;

--- a/client/src/components/molecules/Modal/Modal.tsx
+++ b/client/src/components/molecules/Modal/Modal.tsx
@@ -5,11 +5,12 @@ import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import Title from '@atoms/p/LeftLargeText';
 import Closed from '@atoms/button/TextButton';
 import myColor from '@theme/color';
+import { hideModal } from '@actions/modal/type';
+import { useDispatch } from 'react-redux';
 
 interface Props extends modalProps {
   title?: string;
   children: React.ReactChild[] | React.ReactChild;
-  onClick?: () => void;
 }
 
 interface modalProps {
@@ -21,7 +22,6 @@ const defaultProps = {
   title: '',
   width: '80%',
   height: '60%',
-  onClick: undefined,
 };
 
 const ModalBackground = styled.div`
@@ -50,9 +50,15 @@ const ButtonContainer = styled.div`
   margin-left: auto;
 `;
 
-const Modal: React.FC<Props> = ({ title, onClick, children, ...props }: Props) => {
+const Modal: React.FC<Props> = ({ title, children, ...props }: Props) => {
+  const dispatch = useDispatch();
+
+  const closeModal = () => {
+    dispatch(hideModal());
+  };
+
   return (
-    <ModalBackground>
+    <ModalBackground onClick={closeModal}>
       <ModalContainer {...props}>
         <ColumnFlexContainer>
           <RowFlexContainer width="100%" margin="10px 0">
@@ -60,7 +66,7 @@ const Modal: React.FC<Props> = ({ title, onClick, children, ...props }: Props) =
               <>{title}</>
             </Title>
             <ButtonContainer>
-              <Closed onClick={onClick} color="black">
+              <Closed onClick={closeModal} color="black">
                 X
               </Closed>
             </ButtonContainer>

--- a/client/src/components/organisms/AccountBookAcceptModal/AccountBookAcceptModal.stories.tsx
+++ b/client/src/components/organisms/AccountBookAcceptModal/AccountBookAcceptModal.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import AccountBookAcceptModal from './AccountBookAcceptModal';
+
+export default {
+  title: 'Organisms/AccountBookAcceptModal',
+  component: AccountBookAcceptModal,
+};
+
+export const accountBookAcceptModal = (): JSX.Element => {
+  return <AccountBookAcceptModal />;
+};
+
+accountBookAcceptModal.story = {
+  name: 'AccountBookAcceptModal',
+};

--- a/client/src/components/organisms/AccountBookAcceptModal/AccountBookAcceptModal.tsx
+++ b/client/src/components/organisms/AccountBookAcceptModal/AccountBookAcceptModal.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Modal from '@molecules/Modal';
+
+const AccountBookAcceptModal: React.FC = () => {
+  const title = '가계부 승인/거절';
+
+  return (
+    <Modal title={title}>
+      <p>가계부 승인/거절 모달입니다</p>
+    </Modal>
+  );
+};
+
+export default AccountBookAcceptModal;

--- a/client/src/components/organisms/AccountBookAcceptModal/index.ts
+++ b/client/src/components/organisms/AccountBookAcceptModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AccountBookAcceptModal';

--- a/client/src/components/organisms/CreditCardEditModal/CreditCardEditModal.stories.tsx
+++ b/client/src/components/organisms/CreditCardEditModal/CreditCardEditModal.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import CreditCardEditModal from './CreditCardEditModal';
+
+export default {
+  title: 'Organisms/CreditCardEditModal',
+  component: CreditCardEditModal,
+};
+
+export const creditCardEditModal = (): JSX.Element => {
+  return <CreditCardEditModal />;
+};
+
+creditCardEditModal.story = {
+  name: 'CreditCardEditModal',
+};

--- a/client/src/components/organisms/CreditCardEditModal/CreditCardEditModal.tsx
+++ b/client/src/components/organisms/CreditCardEditModal/CreditCardEditModal.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Modal from '@molecules/Modal';
+
+const CreditCardEditModal: React.FC = () => {
+  const title = '결제 수단 관리';
+
+  return (
+    <Modal title={title}>
+      <p>결제 수단 관리 모달입니다</p>
+    </Modal>
+  );
+};
+
+export default CreditCardEditModal;

--- a/client/src/components/organisms/CreditCardEditModal/index.ts
+++ b/client/src/components/organisms/CreditCardEditModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CreditCardEditModal';

--- a/client/src/components/organisms/MyPageMenu/MyPageMenu.tsx
+++ b/client/src/components/organisms/MyPageMenu/MyPageMenu.tsx
@@ -6,7 +6,8 @@ import AccountBookSVG from '@svg/check-piggy-bank.svg';
 import CreditCardSVG from '@svg/credit-card.svg';
 import UserInfoSVG from '@svg/fix.svg';
 import myColor from '@theme/color';
-import 'dotenv/config';
+import { showModal } from '@actions/modal/type';
+import { useDispatch } from 'react-redux';
 
 const TopMenuBox = styled.div`
   display: flex;
@@ -19,18 +20,20 @@ const BottomMenuBox = styled.div`
   margin-top: -32px;
 `;
 
-const onClick = (): boolean => {
-  return true;
-};
-
 const MyPageMenu: React.FC = () => {
+  const dispatch = useDispatch();
+
+  const openModal = (view: string) => {
+    dispatch(showModal(view));
+  };
+
   const accountBookSVG = <AccountBookSVG width={40} height={40} fill={myColor.primary.brown} />;
   const accountBookMenu = (
     <HexagonButton
       name="가계부 승인/거절"
       color={myColor.primary.main}
       svgIcon={accountBookSVG}
-      onClick={onClick}
+      onClick={() => openModal('AccountBookAccept')}
     />
   );
 
@@ -40,7 +43,7 @@ const MyPageMenu: React.FC = () => {
       name="결제 수단 관리"
       color={myColor.primary.light}
       svgIcon={creditCardSVG}
-      onClick={onClick}
+      onClick={() => openModal('CreditCardEdit')}
     />
   );
 
@@ -50,7 +53,7 @@ const MyPageMenu: React.FC = () => {
       name="개인 정보 변경"
       color={myColor.primary.dark}
       svgIcon={userInfoSVG}
-      onClick={onClick}
+      onClick={() => openModal('UserInfoSetting')}
     />
   );
   return (

--- a/client/src/components/organisms/UserInfoSettingModal/UserInfoSettingModal.stories.tsx
+++ b/client/src/components/organisms/UserInfoSettingModal/UserInfoSettingModal.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import UserInfoSettingModal from './UserInfoSettingModal';
+
+export default {
+  title: 'Organisms/UserInfoSettingModal',
+  component: UserInfoSettingModal,
+};
+
+export const userInfoSettingModal = (): JSX.Element => {
+  return <UserInfoSettingModal />;
+};
+
+userInfoSettingModal.story = {
+  name: 'UserInfoSettingModal',
+};

--- a/client/src/components/organisms/UserInfoSettingModal/UserInfoSettingModal.tsx
+++ b/client/src/components/organisms/UserInfoSettingModal/UserInfoSettingModal.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Modal from '@molecules/Modal';
+
+const AccountBookAcceptModal: React.FC = () => {
+  const title = '개인 정보 변경';
+
+  return (
+    <Modal title={title}>
+      <p>개인 정보 변경 모달입니다</p>
+    </Modal>
+  );
+};
+
+export default AccountBookAcceptModal;

--- a/client/src/components/organisms/UserInfoSettingModal/index.ts
+++ b/client/src/components/organisms/UserInfoSettingModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './UserInfoSettingModal';

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import initStore from '@store/index';
+import { Provider } from 'react-redux';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
+const store = initStore();
+
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
   document.getElementById('root'),
 );

--- a/client/src/reducers/modal.ts
+++ b/client/src/reducers/modal.ts
@@ -1,26 +1,21 @@
-import {
-  ACCOUNTBOOK_OPEN,
-  ACCOUNTBOOK_CLOSE,
-  accountbookOpen,
-  accountbookClose,
-} from '@actions/modal/type';
+import { SHOW_MODAL, HIDE_MODAL, showModal, hideModal } from '@actions/modal/type';
 
-type ModalAction = ReturnType<typeof accountbookOpen> | ReturnType<typeof accountbookClose>;
+type ModalAction = ReturnType<typeof showModal> | ReturnType<typeof hideModal>;
 
 type ModalState = {
-  isOpen: boolean;
+  view: string;
 };
 
 const initialState: ModalState = {
-  isOpen: true,
+  view: 'AccountBook',
 };
 
 const modal = (state: ModalState = initialState, action: ModalAction): ModalState => {
   switch (action.type) {
-    case ACCOUNTBOOK_OPEN:
-      return { isOpen: true };
-    case ACCOUNTBOOK_CLOSE:
-      return { isOpen: false };
+    case SHOW_MODAL:
+      return { view: action.payload };
+    case HIDE_MODAL:
+      return { view: 'none' };
     default:
       return state;
   }

--- a/client/src/reducers/modal.ts
+++ b/client/src/reducers/modal.ts
@@ -1,0 +1,29 @@
+import {
+  ACCOUNTBOOK_OPEN,
+  ACCOUNTBOOK_CLOSE,
+  accountbookOpen,
+  accountbookClose,
+} from '@actions/modal/type';
+
+type ModalAction = ReturnType<typeof accountbookOpen> | ReturnType<typeof accountbookClose>;
+
+type ModalState = {
+  isOpen: boolean;
+};
+
+const initialState: ModalState = {
+  isOpen: true,
+};
+
+const modal = (state: ModalState = initialState, action: ModalAction): ModalState => {
+  switch (action.type) {
+    case ACCOUNTBOOK_OPEN:
+      return { isOpen: true };
+    case ACCOUNTBOOK_CLOSE:
+      return { isOpen: false };
+    default:
+      return state;
+  }
+};
+
+export default modal;

--- a/client/src/reducers/rootReducer.ts
+++ b/client/src/reducers/rootReducer.ts
@@ -1,0 +1,10 @@
+import { combineReducers } from 'redux';
+import modal from './modal';
+
+const rootReducer = combineReducers({
+  modal,
+});
+
+export default rootReducer;
+
+export type RootState = ReturnType<typeof rootReducer>;

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,0 +1,9 @@
+import { createStore } from 'redux';
+import rootReducer from '@reducers/rootReducer';
+
+const configureStore: any = (initialState = {}) => {
+  const store = createStore(rootReducer, initialState);
+  return store;
+};
+
+export default configureStore;

--- a/client/src/views/MyPage.tsx
+++ b/client/src/views/MyPage.tsx
@@ -4,12 +4,23 @@ import BeeBackground from '@organisms/BeeBackground';
 import TopNavBar from '@organisms/TopNavBar';
 import MyPageUserMenu from '@organisms/MyPageUserMenu';
 import MyPageMenu from '@organisms/MyPageMenu';
+import Modal from '@molecules/Modal';
+import { accountbookClose } from '@actions/modal/type';
+import { useSelector, useDispatch } from 'react-redux';
+import { RootState } from '@reducers/rootReducer';
 
 const MyPage: React.FC = () => {
+  const isOpen = useSelector((state: RootState) => state.modal.isOpen);
+  const dispatch = useDispatch();
   // TODO : 실제 로그인 유저의 정보를 받아오기
   const name = '임시 이름';
   const profile =
     'https://camo.githubusercontent.com/80afeacc15fc9527cacd6a8257613bcc97967d63947bbb8e2f6efe0a2ed8d59d/68747470733a2f2f692e696d6775722e636f6d2f536c7568554c712e6a7067';
+
+  const closeModal = () => {
+    dispatch(accountbookClose());
+  };
+
   return (
     <>
       <BeeBackground />
@@ -18,6 +29,11 @@ const MyPage: React.FC = () => {
         <MyPageUserMenu name={name} profile={profile} />
         <MyPageMenu />
       </CenterContent>
+      {isOpen && (
+        <Modal onClick={closeModal}>
+          <p>모달입니다!</p>
+        </Modal>
+      )}
     </>
   );
 };

--- a/client/src/views/MyPage.tsx
+++ b/client/src/views/MyPage.tsx
@@ -4,22 +4,18 @@ import BeeBackground from '@organisms/BeeBackground';
 import TopNavBar from '@organisms/TopNavBar';
 import MyPageUserMenu from '@organisms/MyPageUserMenu';
 import MyPageMenu from '@organisms/MyPageMenu';
-import Modal from '@molecules/Modal';
-import { accountbookClose } from '@actions/modal/type';
-import { useSelector, useDispatch } from 'react-redux';
+import AccountBookAcceptModal from '@organisms/AccountBookAcceptModal';
+import CreditCardEditModal from '@organisms/CreditCardEditModal';
+import UserInfoSettingModal from '@organisms/UserInfoSettingModal';
+import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
 
 const MyPage: React.FC = () => {
-  const isOpen = useSelector((state: RootState) => state.modal.isOpen);
-  const dispatch = useDispatch();
+  const modalView = useSelector((state: RootState) => state.modal.view);
   // TODO : 실제 로그인 유저의 정보를 받아오기
   const name = '임시 이름';
   const profile =
     'https://camo.githubusercontent.com/80afeacc15fc9527cacd6a8257613bcc97967d63947bbb8e2f6efe0a2ed8d59d/68747470733a2f2f692e696d6775722e636f6d2f536c7568554c712e6a7067';
-
-  const closeModal = () => {
-    dispatch(accountbookClose());
-  };
 
   return (
     <>
@@ -29,11 +25,9 @@ const MyPage: React.FC = () => {
         <MyPageUserMenu name={name} profile={profile} />
         <MyPageMenu />
       </CenterContent>
-      {isOpen && (
-        <Modal onClick={closeModal}>
-          <p>모달입니다!</p>
-        </Modal>
-      )}
+      {modalView === 'AccountBookAccept' && <AccountBookAcceptModal />}
+      {modalView === 'CreditCardEdit' && <CreditCardEditModal />}
+      {modalView === 'UserInfoSetting' && <UserInfoSettingModal />}
     </>
   );
 };

--- a/client/tsconfig.paths.json
+++ b/client/tsconfig.paths.json
@@ -11,6 +11,7 @@
       "@templates/*": ["src/components/templates/*"],
       "@views/*": ["src/views/*"],
       "@reducers/*": ["src/reducers/*"],
+      "@actions/*": ["src/actions/*"],
       "@store/*": ["src/store/*"],
       "@shared/*": ["src/shared/*"],
       "@hooks/*": ["src/hooks/*"],


### PR DESCRIPTION
### 📕 Issue Number

Close #9 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- Redux를 이용한 modal 구현
    - modal의 닫히는 부분까지 구현해두었기 때문에 추후 개발하시는 분들은 modal organisms을 생성하고 버튼을 눌렀을 때 열리는 부분만 추가해주시면 쉽게 사용하실 수 있습니다.
- 마이페이지의 각 메뉴에 대한 모달 틀 생성 및 열고 닫는 기능 구현

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 새롭게 알게된 내용 공유합니다~ [참고 블로그](https://kss7547.tistory.com/36)
    - 이 부분을 몰라서 삽질을 조금 했습니다😓 다들 한번씩 보시면 좋을 것 같아요😄
- 컴포넌트 분석 문서에 제작한 organisms을 등록만 해두었습니다.
    ![image](https://user-images.githubusercontent.com/50297117/100755221-49ba8580-342f-11eb-9aec-64e2419f4e41.png)
    - 담당하여 개발하는분께서는 해당 파일을 수정하여 작업해주시고 문서 업데이트 해주시면 될 것 같아요😄
- 12/2 스크럼 때 Redux 의 동작방식과 적용 원리에 대해서 설명드리도록 하겠습니다!🔥
- 지우님과 함께 확인하였는데, 스토리북이 조금 깨져있는 문제가 보였습니다. Page 화면에서는 이상이 없는데 아마 component의 속성을 추가하면서 이상해진 것 같아요😥

<br/><br/>