### PR TITLE
FE-feat-createAccountbookPage-ui

### DIFF
--- a/client/src/components/molecules/ChangeAccountbookColorCard/ChangeAccountbookColorCard.stories.tsx
+++ b/client/src/components/molecules/ChangeAccountbookColorCard/ChangeAccountbookColorCard.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ChangeAccountbookColorCard from './ChangeAccountbookColorCard';
 
 export default {
-  title: 'Organisms/ChangeAccountbookColorCard',
+  title: 'molecules/ChangeAccountbookColorCard',
   component: ChangeAccountbookColorCard,
 };
 

--- a/client/src/components/molecules/ChangeAccountbookColorCard/ChangeAccountbookColorCard.stories.tsx
+++ b/client/src/components/molecules/ChangeAccountbookColorCard/ChangeAccountbookColorCard.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+// import myColor from '@theme/color';
+import ChangeAccountbookColorCard from './ChangeAccountbookColorCard';
+
+export default {
+  title: 'Organisms/ChangeAccountbookColorCard',
+  component: ChangeAccountbookColorCard,
+};
+
+export const changeAccountbookColorCard = (): JSX.Element => {
+  return <ChangeAccountbookColorCard />;
+};
+
+changeAccountbookColorCard.story = {
+  name: 'ChangeAccountbookColorCard',
+};

--- a/client/src/components/molecules/ChangeAccountbookColorCard/ChangeAccountbookColorCard.stories.tsx
+++ b/client/src/components/molecules/ChangeAccountbookColorCard/ChangeAccountbookColorCard.stories.tsx
@@ -1,16 +1,26 @@
 import React from 'react';
-// import myColor from '@theme/color';
 import ChangeAccountbookColorCard from './ChangeAccountbookColorCard';
+
+interface Props {
+  labelColor: string;
+}
 
 export default {
   title: 'molecules/ChangeAccountbookColorCard',
   component: ChangeAccountbookColorCard,
+  argTypes: {
+    labelColor: { control: 'color' },
+  },
 };
 
-export const changeAccountbookColorCard = (): JSX.Element => {
-  return <ChangeAccountbookColorCard />;
+export const changeAccountbookColorCard = ({ ...args }: Props): JSX.Element => {
+  return <ChangeAccountbookColorCard {...args} />;
 };
 
 changeAccountbookColorCard.story = {
   name: 'ChangeAccountbookColorCard',
+};
+
+changeAccountbookColorCard.args = {
+  labelColor: 'blue',
 };

--- a/client/src/components/molecules/ChangeAccountbookColorCard/ChangeAccountbookColorCard.tsx
+++ b/client/src/components/molecules/ChangeAccountbookColorCard/ChangeAccountbookColorCard.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+// import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
+// import RowFlexContainer from '@atoms/div/RowFlexContainer';
+// import LeftNormalText from '@atoms/p/LeftNormalText';
+// import TextArea from '@atoms/textarea/TextArea';
+// import styled from 'styled-components';
+import myColor from '@theme/color';
+
+interface Props {
+  backgroundColor?: string;
+}
+
+const defaultProps = {
+  backgroundColor: myColor.primary.main,
+};
+
+const ChangeAccountbookColorCard: React.FC<Props> = () => {
+  return <></>;
+};
+
+ChangeAccountbookColorCard.defaultProps = defaultProps;
+
+export default ChangeAccountbookColorCard;

--- a/client/src/components/molecules/ChangeAccountbookColorCard/ChangeAccountbookColorCard.tsx
+++ b/client/src/components/molecules/ChangeAccountbookColorCard/ChangeAccountbookColorCard.tsx
@@ -1,23 +1,46 @@
 import React from 'react';
-// import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
-// import RowFlexContainer from '@atoms/div/RowFlexContainer';
-// import LeftNormalText from '@atoms/p/LeftNormalText';
-// import TextArea from '@atoms/textarea/TextArea';
-// import styled from 'styled-components';
+import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
+import RowFlexContainer from '@atoms/div/RowFlexContainer';
+import LeftNormalText from '@atoms/p/LeftNormalText';
 import myColor from '@theme/color';
+import SquircleCard from '@atoms/div/SquircleCard';
+import ColorLabel from '@atoms/div/ColorLabel';
+import SquircleShortButton from '@atoms/button/SquircleShortButton';
 
 interface Props {
-  backgroundColor?: string;
+  labelColor: string;
 }
 
-const defaultProps = {
-  backgroundColor: myColor.primary.main,
+interface squircleCardProps {
+  width: string;
+  height: string;
+  backgroundColor: string;
+  flexFlow: string;
+}
+
+const squircleCardArgs: squircleCardProps = {
+  width: '100%',
+  height: '10rem',
+  backgroundColor: 'white',
+  flexFlow: 'column',
 };
 
-const ChangeAccountbookColorCard: React.FC<Props> = () => {
-  return <></>;
+const ChangeAccountbookColorCard: React.FC<Props> = ({ labelColor }: Props) => {
+  return (
+    <SquircleCard {...squircleCardArgs}>
+      <ColumnFlexContainer width="100%" height="100%">
+        <RowFlexContainer width="100%" height="30%">
+          <LeftNormalText fontWeight="bold" color={myColor.primary.black}>
+            색상
+          </LeftNormalText>
+        </RowFlexContainer>
+        <RowFlexContainer justifyContent="space-between" width="100%" height="70%">
+          <ColorLabel backgroundColor={labelColor} />
+          <SquircleShortButton>변경하기</SquircleShortButton>
+        </RowFlexContainer>
+      </ColumnFlexContainer>
+    </SquircleCard>
+  );
 };
-
-ChangeAccountbookColorCard.defaultProps = defaultProps;
 
 export default ChangeAccountbookColorCard;

--- a/client/src/components/molecules/ChangeAccountbookColorCard/index.ts
+++ b/client/src/components/molecules/ChangeAccountbookColorCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ChangeAccountbookColorCard';

--- a/client/src/components/molecules/InviteAccountbookCard/InviteAccountbookCard.stories.tsx
+++ b/client/src/components/molecules/InviteAccountbookCard/InviteAccountbookCard.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+// import myColor from '@theme/color';
+import InviteAccountbookCard from './InviteAccountbookCard';
+
+export default {
+  title: 'Organisms/InviteAccountbookCard',
+  component: InviteAccountbookCard,
+};
+
+export const inviteAccountbookCard = (): JSX.Element => {
+  return <InviteAccountbookCard />;
+};
+
+inviteAccountbookCard.story = {
+  name: 'InviteAccountbookCard',
+};

--- a/client/src/components/molecules/InviteAccountbookCard/InviteAccountbookCard.stories.tsx
+++ b/client/src/components/molecules/InviteAccountbookCard/InviteAccountbookCard.stories.tsx
@@ -2,15 +2,27 @@ import React from 'react';
 // import myColor from '@theme/color';
 import InviteAccountbookCard from './InviteAccountbookCard';
 
+interface Props {
+  links: string[];
+}
+
 export default {
-  title: 'Organisms/InviteAccountbookCard',
+  title: 'molecules/InviteAccountbookCard',
   component: InviteAccountbookCard,
 };
 
-export const inviteAccountbookCard = (): JSX.Element => {
-  return <InviteAccountbookCard />;
+export const inviteAccountbookCard = ({ ...args }: Props): JSX.Element => {
+  return <InviteAccountbookCard {...args} />;
 };
 
 inviteAccountbookCard.story = {
   name: 'InviteAccountbookCard',
+};
+
+inviteAccountbookCard.args = {
+  links: [
+    'https://avatars2.githubusercontent.com/u/46099115?s=460&u=1e04610d430875d8189d2b212b8c2d9fc268b9db&v=4',
+    'https://avatars3.githubusercontent.com/u/55074799?s=460&u=2f70319c2f55ba5e26db060ba21d66a9cab35732&v=4',
+    'https://avatars2.githubusercontent.com/u/50297117?s=460&u=2ddc78ef0045b75f6fb405f1763304a7481d46e4&v=4',
+  ],
 };

--- a/client/src/components/molecules/InviteAccountbookCard/InviteAccountbookCard.tsx
+++ b/client/src/components/molecules/InviteAccountbookCard/InviteAccountbookCard.tsx
@@ -1,23 +1,45 @@
 import React from 'react';
-// import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
-// import RowFlexContainer from '@atoms/div/RowFlexContainer';
-// import LeftNormalText from '@atoms/p/LeftNormalText';
-// import TextArea from '@atoms/textarea/TextArea';
-// import styled from 'styled-components';
+import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
+import RowFlexContainer from '@atoms/div/RowFlexContainer';
+import LeftNormalText from '@atoms/p/LeftNormalText';
 import myColor from '@theme/color';
+import UserImages from '@molecules/UserImages';
+import SquircleCard from '@atoms/div/SquircleCard';
+import SquircleShortButton from '@atoms/button/SquircleShortButton';
 
 interface Props {
-  backgroundColor?: string;
+  links: string[];
 }
 
-const defaultProps = {
-  backgroundColor: myColor.primary.main,
+interface squircleCardProps {
+  width: string;
+  height: string;
+  backgroundColor: string;
+  flexFlow: string;
+}
+
+const squircleCardArgs: squircleCardProps = {
+  width: '100%',
+  height: '10rem',
+  backgroundColor: 'white',
+  flexFlow: 'column',
 };
 
-const InviteAccountbookCard: React.FC<Props> = () => {
-  return <></>;
+const InviteAccountbookCard: React.FC<Props> = ({ links }: Props) => {
+  return (
+    <SquircleCard {...squircleCardArgs}>
+      <ColumnFlexContainer width="100%" height="100%">
+        <RowFlexContainer width="100%" height="30%">
+          <LeftNormalText fontWeight="bold" color={myColor.primary.black}>
+            초대 목록
+          </LeftNormalText>
+        </RowFlexContainer>
+        <RowFlexContainer justifyContent="space-between" width="100%" height="70%">
+          <UserImages links={links} />
+          <SquircleShortButton>초대하기</SquircleShortButton>
+        </RowFlexContainer>
+      </ColumnFlexContainer>
+    </SquircleCard>
+  );
 };
-
-InviteAccountbookCard.defaultProps = defaultProps;
-
 export default InviteAccountbookCard;

--- a/client/src/components/molecules/InviteAccountbookCard/InviteAccountbookCard.tsx
+++ b/client/src/components/molecules/InviteAccountbookCard/InviteAccountbookCard.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+// import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
+// import RowFlexContainer from '@atoms/div/RowFlexContainer';
+// import LeftNormalText from '@atoms/p/LeftNormalText';
+// import TextArea from '@atoms/textarea/TextArea';
+// import styled from 'styled-components';
+import myColor from '@theme/color';
+
+interface Props {
+  backgroundColor?: string;
+}
+
+const defaultProps = {
+  backgroundColor: myColor.primary.main,
+};
+
+const InviteAccountbookCard: React.FC<Props> = () => {
+  return <></>;
+};
+
+InviteAccountbookCard.defaultProps = defaultProps;
+
+export default InviteAccountbookCard;

--- a/client/src/components/molecules/InviteAccountbookCard/index.ts
+++ b/client/src/components/molecules/InviteAccountbookCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './InviteAccountbookCard';

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.stories.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import myColor from '@theme/color';
+import CreateAccountbookFormBox from './CreateAccountbookFormBox';
+
+export default {
+  title: 'Organisms/CreateAccountbookFormBox',
+  component: CreateAccountbookFormBox,
+};
+
+export const createAccountbookFormBox = (): JSX.Element => {
+  return <CreateAccountbookFormBox backgroundColor={myColor.primary.main} />;
+};
+
+createAccountbookFormBox.story = {
+  name: 'CreateAccountbookFormBox',
+};

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import LeftNormalText from '@atoms/p/LeftNormalText';
+import LeftLargeText from '@atoms/p/LeftLargeText';
 import TextArea from '@atoms/textarea/TextArea';
 import myColor from '@theme/color';
 import SquircleCard from '@atoms/div/SquircleCard';
+import RoundShortButton from '@atoms/button/RoundShortButton';
 
 interface Props {
   backgroundColor?: string;
@@ -16,16 +18,26 @@ const defaultProps = {
 
 const CreateAccountbookFormBox: React.FC<Props> = ({ backgroundColor }: Props) => {
   return (
-    <SquircleCard width="100%" backgroundColor={backgroundColor} height="25rem">
+    <SquircleCard width="100%" backgroundColor={backgroundColor} height="15rem">
       <ColumnFlexContainer
         width="100%"
-        height="100%"
+        height="12rem"
         justifyContent="space-around"
-        margin="2rem 0 0 0"
+        margin="2rem 1rem 0"
+        alignItems="center"
       >
-        <RowFlexContainer>가계부 생성, 버튼</RowFlexContainer>
-        <LeftNormalText>이름을 입력해주세요.</LeftNormalText>
-        <TextArea width="80%" height="30%" />
+        <RowFlexContainer width="100%" justifyContent="space-between">
+          <LeftLargeText color="white" fontWeight="bold">
+            가계부 생성
+          </LeftLargeText>
+          <RoundShortButton backgroundColor="black" color="white">
+            검색
+          </RoundShortButton>
+        </RowFlexContainer>
+        <RowFlexContainer width="100%" justifyContent="baseline">
+          <LeftNormalText color="white">이름을 입력해주세요.</LeftNormalText>
+        </RowFlexContainer>
+        <TextArea width="100%" height="30%" />
       </ColumnFlexContainer>
     </SquircleCard>
   );

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
@@ -18,7 +18,7 @@ const FormBoxContainer = styled.div<Props>`
   background-color: ${(props) => props.backgroundColor};
 `;
 
-const CreateAccountbokoFormBox: React.FC<Props> = ({ backgroundColor }: Props) => {
+const CreateAccountbookFormBox: React.FC<Props> = ({ backgroundColor }: Props) => {
   return (
     <FormBoxContainer backgroundColor={backgroundColor}>
       <ColumnFlexContainer margin="2rem 0 0 0">
@@ -30,6 +30,6 @@ const CreateAccountbokoFormBox: React.FC<Props> = ({ backgroundColor }: Props) =
   );
 };
 
-CreateAccountbokoFormBox.defaultProps = defaultProps;
+CreateAccountbookFormBox.defaultProps = defaultProps;
 
-export default CreateAccountbokoFormBox;
+export default CreateAccountbookFormBox;

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
-import LeftNormalText from '@atoms/p/LeftNormalText';
 import LeftLargeText from '@atoms/p/LeftLargeText';
 import TextArea from '@atoms/textarea/TextArea';
 import myColor from '@theme/color';
@@ -31,11 +30,11 @@ const CreateAccountbookFormBox: React.FC<Props> = ({ backgroundColor }: Props) =
             가계부 생성
           </LeftLargeText>
           <RoundShortButton backgroundColor="black" color="white">
-            검색
+            생성
           </RoundShortButton>
         </RowFlexContainer>
         <RowFlexContainer width="100%" justifyContent="baseline">
-          <LeftNormalText color="white">이름을 입력해주세요.</LeftNormalText>
+          <LeftLargeText color="white">이름을 입력해주세요.</LeftLargeText>
         </RowFlexContainer>
         <TextArea width="100%" height="30%" />
       </ColumnFlexContainer>

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
@@ -3,19 +3,17 @@ import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import LeftLargeText from '@atoms/p/LeftLargeText';
 import TextArea from '@atoms/textarea/TextArea';
-import myColor from '@theme/color';
 import SquircleCard from '@atoms/div/SquircleCard';
 import RoundShortButton from '@atoms/button/RoundShortButton';
+import colorUtils from '@utils/color';
 
 interface Props {
-  backgroundColor?: string;
+  backgroundColor: string;
 }
 
-const defaultProps = {
-  backgroundColor: myColor.primary.main,
-};
-
 const CreateAccountbookFormBox: React.FC<Props> = ({ backgroundColor }: Props) => {
+  const fontColor = colorUtils.getFontColor(backgroundColor);
+  const buttonColor = fontColor === 'white' ? 'black' : 'white';
   return (
     <SquircleCard width="100%" backgroundColor={backgroundColor} height="15rem">
       <ColumnFlexContainer
@@ -26,22 +24,20 @@ const CreateAccountbookFormBox: React.FC<Props> = ({ backgroundColor }: Props) =
         alignItems="center"
       >
         <RowFlexContainer width="100%" justifyContent="space-between">
-          <LeftLargeText color="white" fontWeight="bold">
+          <LeftLargeText color={fontColor} fontWeight="bold">
             가계부 생성
           </LeftLargeText>
-          <RoundShortButton backgroundColor="black" color="white">
+          <RoundShortButton backgroundColor={buttonColor} color={fontColor}>
             생성
           </RoundShortButton>
         </RowFlexContainer>
         <RowFlexContainer width="100%" justifyContent="baseline">
-          <LeftLargeText color="white">이름을 입력해주세요.</LeftLargeText>
+          <LeftLargeText color={fontColor}>이름을 입력해주세요.</LeftLargeText>
         </RowFlexContainer>
         <TextArea width="100%" height="30%" />
       </ColumnFlexContainer>
     </SquircleCard>
   );
 };
-
-CreateAccountbookFormBox.defaultProps = defaultProps;
 
 export default CreateAccountbookFormBox;

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
+import RowFlexContainer from '@atoms/div/RowFlexContainer';
+import LeftNormalText from '@atoms/p/LeftNormalText';
+import TextArea from '@atoms/textarea/TextArea';
+import styled from 'styled-components';
+import myColor from '@theme/color';
+
+interface Props {
+  backgroundColor?: string;
+}
+
+const defaultProps = {
+  backgroundColor: myColor.primary.main,
+};
+
+const FormBoxContainer = styled.div<Props>`
+  background-color: ${(props) => props.backgroundColor};
+`;
+
+const CreateAccountbokoFormBox: React.FC<Props> = ({ backgroundColor }: Props) => {
+  return (
+    <FormBoxContainer backgroundColor={backgroundColor}>
+      <ColumnFlexContainer margin="2rem 0 0 0">
+        <RowFlexContainer>가계부 생성, 버튼</RowFlexContainer>
+        <LeftNormalText>이름을 입력해주세요.</LeftNormalText>
+        <TextArea width="100%" height="100%" />
+      </ColumnFlexContainer>
+    </FormBoxContainer>
+  );
+};
+
+CreateAccountbokoFormBox.defaultProps = defaultProps;
+
+export default CreateAccountbokoFormBox;

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
@@ -3,8 +3,8 @@ import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import LeftNormalText from '@atoms/p/LeftNormalText';
 import TextArea from '@atoms/textarea/TextArea';
-import styled from 'styled-components';
 import myColor from '@theme/color';
+import SquircleCard from '@atoms/div/SquircleCard';
 
 interface Props {
   backgroundColor?: string;
@@ -14,19 +14,20 @@ const defaultProps = {
   backgroundColor: myColor.primary.main,
 };
 
-const FormBoxContainer = styled.div<Props>`
-  background-color: ${(props) => props.backgroundColor};
-`;
-
 const CreateAccountbookFormBox: React.FC<Props> = ({ backgroundColor }: Props) => {
   return (
-    <FormBoxContainer backgroundColor={backgroundColor}>
-      <ColumnFlexContainer margin="2rem 0 0 0">
+    <SquircleCard width="100%" backgroundColor={backgroundColor} height="25rem">
+      <ColumnFlexContainer
+        width="100%"
+        height="100%"
+        justifyContent="space-around"
+        margin="2rem 0 0 0"
+      >
         <RowFlexContainer>가계부 생성, 버튼</RowFlexContainer>
         <LeftNormalText>이름을 입력해주세요.</LeftNormalText>
-        <TextArea width="100%" height="100%" />
+        <TextArea width="80%" height="30%" />
       </ColumnFlexContainer>
-    </FormBoxContainer>
+    </SquircleCard>
   );
 };
 

--- a/client/src/components/organisms/CreateAccountbookFormBox/index.ts
+++ b/client/src/components/organisms/CreateAccountbookFormBox/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CreateAccountbookFormBox';

--- a/client/src/components/organisms/CreateAccountbookSetting/CreateAccountbookSetting.stories.tsx
+++ b/client/src/components/organisms/CreateAccountbookSetting/CreateAccountbookSetting.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+// import myColor from '@theme/color';
+import CreateAccountbookSetting from './CreateAccountbookSetting';
+
+export default {
+  title: 'Organisms/CreateAccountbookSetting',
+  component: CreateAccountbookSetting,
+};
+
+export const createAccountbookSetting = (): JSX.Element => {
+  return <CreateAccountbookSetting />;
+};
+
+createAccountbookSetting.story = {
+  name: 'CreateAccountbookSetting',
+};

--- a/client/src/components/organisms/CreateAccountbookSetting/CreateAccountbookSetting.stories.tsx
+++ b/client/src/components/organisms/CreateAccountbookSetting/CreateAccountbookSetting.stories.tsx
@@ -2,15 +2,32 @@ import React from 'react';
 // import myColor from '@theme/color';
 import CreateAccountbookSetting from './CreateAccountbookSetting';
 
+interface Props {
+  links: string[];
+  labelColor: string;
+}
+
 export default {
   title: 'Organisms/CreateAccountbookSetting',
   component: CreateAccountbookSetting,
+  argTypes: {
+    labelColor: { control: 'color' },
+  },
 };
 
-export const createAccountbookSetting = (): JSX.Element => {
-  return <CreateAccountbookSetting />;
+export const createAccountbookSetting = ({ ...args }: Props): JSX.Element => {
+  return <CreateAccountbookSetting {...args} />;
 };
 
 createAccountbookSetting.story = {
   name: 'CreateAccountbookSetting',
+};
+
+createAccountbookSetting.args = {
+  links: [
+    'https://avatars2.githubusercontent.com/u/46099115?s=460&u=1e04610d430875d8189d2b212b8c2d9fc268b9db&v=4',
+    'https://avatars3.githubusercontent.com/u/55074799?s=460&u=2f70319c2f55ba5e26db060ba21d66a9cab35732&v=4',
+    'https://avatars2.githubusercontent.com/u/50297117?s=460&u=2ddc78ef0045b75f6fb405f1763304a7481d46e4&v=4',
+  ],
+  labelColor: 'blue',
 };

--- a/client/src/components/organisms/CreateAccountbookSetting/CreateAccountbookSetting.tsx
+++ b/client/src/components/organisms/CreateAccountbookSetting/CreateAccountbookSetting.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-// import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
-// import RowFlexContainer from '@atoms/div/RowFlexContainer';
-// import LeftNormalText from '@atoms/p/LeftNormalText';
-// import TextArea from '@atoms/textarea/TextArea';
 // import styled from 'styled-components';
 import myColor from '@theme/color';
+import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
+import InviteAccountbookCard from '@molecules/InviteAccountbookCard';
+import ChangeAccountbookColorCard from '@molecules/ChangeAccountbookColorCard';
 
 interface Props {
   backgroundColor?: string;
@@ -15,7 +14,12 @@ const defaultProps = {
 };
 
 const CreateAccountbookSetting: React.FC<Props> = () => {
-  return <></>;
+  return (
+    <ColumnFlexContainer margin="2rem 0 0 0 ">
+      <InviteAccountbookCard />
+      <ChangeAccountbookColorCard />
+    </ColumnFlexContainer>
+  );
 };
 
 CreateAccountbookSetting.defaultProps = defaultProps;

--- a/client/src/components/organisms/CreateAccountbookSetting/CreateAccountbookSetting.tsx
+++ b/client/src/components/organisms/CreateAccountbookSetting/CreateAccountbookSetting.tsx
@@ -1,27 +1,21 @@
 import React from 'react';
 // import styled from 'styled-components';
-import myColor from '@theme/color';
 import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
 import InviteAccountbookCard from '@molecules/InviteAccountbookCard';
 import ChangeAccountbookColorCard from '@molecules/ChangeAccountbookColorCard';
 
 interface Props {
-  backgroundColor?: string;
+  links: string[];
+  labelColor: string;
 }
 
-const defaultProps = {
-  backgroundColor: myColor.primary.main,
-};
-
-const CreateAccountbookSetting: React.FC<Props> = () => {
+const CreateAccountbookSetting: React.FC<Props> = ({ links, labelColor }: Props) => {
   return (
     <ColumnFlexContainer margin="2rem 0 0 0 ">
-      <InviteAccountbookCard />
-      <ChangeAccountbookColorCard />
+      <InviteAccountbookCard links={links} />
+      <ChangeAccountbookColorCard labelColor={labelColor} />
     </ColumnFlexContainer>
   );
 };
-
-CreateAccountbookSetting.defaultProps = defaultProps;
 
 export default CreateAccountbookSetting;

--- a/client/src/components/organisms/CreateAccountbookSetting/CreateAccountbookSetting.tsx
+++ b/client/src/components/organisms/CreateAccountbookSetting/CreateAccountbookSetting.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+// import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
+// import RowFlexContainer from '@atoms/div/RowFlexContainer';
+// import LeftNormalText from '@atoms/p/LeftNormalText';
+// import TextArea from '@atoms/textarea/TextArea';
+// import styled from 'styled-components';
+import myColor from '@theme/color';
+
+interface Props {
+  backgroundColor?: string;
+}
+
+const defaultProps = {
+  backgroundColor: myColor.primary.main,
+};
+
+const CreateAccountbookSetting: React.FC<Props> = () => {
+  return <></>;
+};
+
+CreateAccountbookSetting.defaultProps = defaultProps;
+
+export default CreateAccountbookSetting;

--- a/client/src/components/organisms/CreateAccountbookSetting/index.ts
+++ b/client/src/components/organisms/CreateAccountbookSetting/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CreateAccountbookSetting';

--- a/client/src/components/organisms/TopNavBar/TopNavBar.tsx
+++ b/client/src/components/organisms/TopNavBar/TopNavBar.tsx
@@ -4,14 +4,22 @@ import myColor from '@theme/color';
 import HomeButton from '@atoms/button/HomeButton';
 import NavButton from '@atoms/button/NavButton';
 
-const FlexRowBox = styled.div`
+interface Props {
+  backgroundColor?: string;
+}
+
+const defaultProps = {
+  backgroundColor: myColor.primary.main,
+};
+
+const FlexRowBox = styled.div<Props>`
   display: flex;
   flex-flow: row;
   justify-content: space-between;
   align-items: center;
   width: 100%;
   height: 2rem;
-  background-color: ${myColor.primary.main};
+  background-color: ${(props) => props.backgroundColor};
   z-index: 1;
   position: fixed;
 `;
@@ -26,9 +34,9 @@ const FlexRowContainer = styled.div`
   background-color: transparent;
 `;
 
-const TopNavBar: React.FC = () => {
+const TopNavBar: React.FC<Props> = ({ backgroundColor }: Props) => {
   return (
-    <FlexRowBox>
+    <FlexRowBox backgroundColor={backgroundColor}>
       <HomeButton />
       <FlexRowContainer>
         <NavButton
@@ -49,5 +57,7 @@ const TopNavBar: React.FC = () => {
     </FlexRowBox>
   );
 };
+
+TopNavBar.defaultProps = defaultProps;
 
 export default TopNavBar;

--- a/client/src/theme/color.ts
+++ b/client/src/theme/color.ts
@@ -20,6 +20,7 @@ const myColor: Colors = {
     black: '#2F2E2D',
     brown: '#7A5A00',
     white: '#FFFFFF',
+    purple: '#6F70B9',
   },
   money: {
     expenditure: '#7392FF',

--- a/client/src/utils/color.ts
+++ b/client/src/utils/color.ts
@@ -1,0 +1,15 @@
+const getFontColor = (color: string): string => {
+  const redValue = parseInt(color.substring(1, 3), 16);
+  const greenValue = parseInt(color.substring(3, 5), 16);
+  const blueValue = parseInt(color.substring(5, 7), 16);
+  const result = (redValue * 0.299 + greenValue * 0.587 + blueValue * 0.114) / 255;
+  if (result >= 0.5) return 'black';
+  return 'white';
+};
+
+const getRandomColor = (): string => {
+  const color = `#${Math.round(Math.random() * 0xffffff).toString(16)}`;
+  return color;
+};
+
+export default { getFontColor, getRandomColor };

--- a/client/src/views/CreateAccountbookPage.tsx
+++ b/client/src/views/CreateAccountbookPage.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import ColoredBackground from '@organisms/ColoredBackground';
 import myColor from '@theme/color';
 import CenterContent from '@molecules/CenterContent';
-import CreateAccountbookForm from '@organisms/CreateAccountbookFormBox';
+import CreateAccountbookFormBox from '@organisms/CreateAccountbookFormBox';
 import TopNavBar from '@organisms/TopNavBar';
+import CreateAccountbookSetting from '@organisms/CreateAccountbookSetting';
 
 const CreateAccountbookPage: React.FC = () => {
   return (
@@ -11,7 +12,15 @@ const CreateAccountbookPage: React.FC = () => {
       <ColoredBackground backgroundColor={myColor.primary.lightGray} />
       <CenterContent>
         <TopNavBar />
-        <CreateAccountbookForm backgroundColor={myColor.primary.main} />
+        <CreateAccountbookFormBox backgroundColor={myColor.primary.main} />
+        <CreateAccountbookSetting
+          labelColor="blue"
+          links={[
+            'https://avatars2.githubusercontent.com/u/46099115?s=460&u=1e04610d430875d8189d2b212b8c2d9fc268b9db&v=4',
+            'https://avatars3.githubusercontent.com/u/55074799?s=460&u=2f70319c2f55ba5e26db060ba21d66a9cab35732&v=4',
+            'https://avatars2.githubusercontent.com/u/50297117?s=460&u=2ddc78ef0045b75f6fb405f1763304a7481d46e4&v=4',
+          ]}
+        />
       </CenterContent>
     </>
   );

--- a/client/src/views/CreateAccountbookPage.tsx
+++ b/client/src/views/CreateAccountbookPage.tsx
@@ -12,7 +12,7 @@ const CreateAccountbookPage: React.FC = () => {
       <ColoredBackground backgroundColor={myColor.primary.lightGray} />
       <CenterContent>
         <TopNavBar />
-        <CreateAccountbookFormBox backgroundColor={myColor.primary.main} />
+        <CreateAccountbookFormBox backgroundColor={myColor.primary.purple} />
         <CreateAccountbookSetting
           labelColor="blue"
           links={[

--- a/client/src/views/CreateAccountbookPage.tsx
+++ b/client/src/views/CreateAccountbookPage.tsx
@@ -11,7 +11,7 @@ const CreateAccountbookPage: React.FC = () => {
     <>
       <ColoredBackground backgroundColor={myColor.primary.lightGray} />
       <CenterContent>
-        <TopNavBar />
+        <TopNavBar backgroundColor={myColor.primary.purple} />
         <CreateAccountbookFormBox backgroundColor={myColor.primary.purple} />
         <CreateAccountbookSetting
           labelColor="blue"

--- a/client/src/views/CreateAccountbookPage.tsx
+++ b/client/src/views/CreateAccountbookPage.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import ColoredBackground from '@organisms/ColoredBackground';
 import myColor from '@theme/color';
-// import TopNavBar from '../components/organisms/TopNavBar';
+import CenterContent from '@molecules/CenterContent';
+import CreateAccountbookForm from '@organisms/CreateAccountbookFormBox';
+import TopNavBar from '@organisms/TopNavBar';
 
 const CreateAccountbookPage: React.FC = () => {
   return (
     <>
       <ColoredBackground backgroundColor={myColor.primary.lightGray} />
+      <CenterContent>
+        <TopNavBar />
+        <CreateAccountbookForm backgroundColor={myColor.primary.main} />
+      </CenterContent>
     </>
   );
 };

--- a/client/src/views/CreateAccountbookPage.tsx
+++ b/client/src/views/CreateAccountbookPage.tsx
@@ -5,14 +5,16 @@ import CenterContent from '@molecules/CenterContent';
 import CreateAccountbookFormBox from '@organisms/CreateAccountbookFormBox';
 import TopNavBar from '@organisms/TopNavBar';
 import CreateAccountbookSetting from '@organisms/CreateAccountbookSetting';
+import colorUtils from '@utils/color';
 
 const CreateAccountbookPage: React.FC = () => {
+  const backgroundColor = colorUtils.getRandomColor();
   return (
     <>
       <ColoredBackground backgroundColor={myColor.primary.lightGray} />
       <CenterContent>
-        <TopNavBar backgroundColor={myColor.primary.purple} />
-        <CreateAccountbookFormBox backgroundColor={myColor.primary.purple} />
+        <TopNavBar backgroundColor={backgroundColor} />
+        <CreateAccountbookFormBox backgroundColor={backgroundColor} />
         <CreateAccountbookSetting
           labelColor="blue"
           links={[
@@ -25,16 +27,5 @@ const CreateAccountbookPage: React.FC = () => {
     </>
   );
 };
-
-/*
-<ColoredBackground backgroundColor={myColor.primary.lightGray} />
-      <CenterContent>
-        <ColumnFlexContainer>
-          <TopNavBar />
-          <CreateAccountbookForm />
-          <AccountbookSetting />
-        </ColumnFlexContainer>
-      </CenterContent>
-*/
 
 export default CreateAccountbookPage;


### PR DESCRIPTION
### 📕 Issue Number

Close #64 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- Views
   - CreateAccountbookPage
![image](https://user-images.githubusercontent.com/61405355/100755166-3a3b3c80-342f-11eb-95cb-3198c1ff667d.png)

- Organisms
   - CreateAccountbookFormBox
![image](https://user-images.githubusercontent.com/61405355/100755336-6d7dcb80-342f-11eb-8e50-8aafc453a0ed.png)
   - CreateAccountbookSetting
![image](https://user-images.githubusercontent.com/61405355/100755398-7bcbe780-342f-11eb-9748-092a1a052929.png)

- Molecules
   - InviteAccountbookCard
![image](https://user-images.githubusercontent.com/61405355/100755851-f85ec600-342f-11eb-88d0-103cc2affb49.png)

   - ChangeAccountbookColorCard
![image](https://user-images.githubusercontent.com/61405355/100755900-0280c480-3430-11eb-97af-95c7950d464e.png)

- TopNav에서 backgroundColor를 Props로 넘길 수 있도록 리팩토링

- themes color primary에 purple 추가
<br/>

### 📘 작업 유형

- 신규 기능 추가
- 리펙토링

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 가계부 생성 페이지 UI 틀 작성했습니다. 수정, 요구사항 피드백은 언제나 환영입니다!!
- TopNav organisms에 대해서 interface Props로 backgroundColor를 선택적으로 넘길 수 있도록 리팩토링 했습니다. 확인해주시고 나중에 사용하시면 될 것 같습니다.

<br/><br/>