### PR TITLE
FE-feat-내역,달력,통계 페이지 생성 및 연동

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,8 @@ import MainPage from '@views/MainPage';
 import NotificationPage from '@views/NotificationPage';
 import MyPage from '@views/MyPage';
 import CreateAccountbookPage from '@views/CreateAccountbookPage';
+import Accountbook from '@views/Accountbook';
+
 import GlobalStyle from '@shared/global';
 import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import { CookiesProvider } from 'react-cookie';
@@ -17,6 +19,7 @@ const App: React.FC = () => {
         <Route path="/notification" component={NotificationPage} />
         <Route path="/mypage" component={MyPage} />
         <Route path="/createAccountbook" component={CreateAccountbookPage} />
+        <Route path="/accountbook" component={Accountbook} />
         <Redirect from="*" to="/" />
       </Switch>
     </>

--- a/client/src/views/Accountbook.tsx
+++ b/client/src/views/Accountbook.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Tabs from '@material-ui/core/Tabs';
@@ -21,7 +21,7 @@ const useStyles = makeStyles({
 
 const Accountbook: React.FC = () => {
   const classes = useStyles();
-  const [value, setValue] = React.useState(0);
+  const [value, setValue] = useState(0);
 
   const handleChange = (event: React.ChangeEvent<any>, newValue: number) => {
     setValue(newValue);

--- a/client/src/views/Accountbook.tsx
+++ b/client/src/views/Accountbook.tsx
@@ -38,7 +38,7 @@ const Accountbook: React.FC = () => {
 
   const tabStyle = {
     textDecoration: 'none',
-    color: myColor.primary.black,
+    color: 'black',
   };
 
   return (
@@ -47,7 +47,13 @@ const Accountbook: React.FC = () => {
       <MarginBox />
       <Router>
         <Paper className={classes.root}>
-          <Tabs value={value} onChange={handleChange} style={tabsStyle} centered>
+          <Tabs
+            value={value}
+            onChange={handleChange}
+            indicatorColor="primary"
+            style={tabsStyle}
+            centered
+          >
             <Link style={tabStyle} to="/accountbook/list" onClick={() => setValue(0)}>
               <Tab label="내역" />
             </Link>

--- a/client/src/views/Accountbook.tsx
+++ b/client/src/views/Accountbook.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import myColor from '@theme/color';
+import TopNavBar from '@organisms/TopNavBar';
+import CenterContent from '@molecules/CenterContent';
+import { BrowserRouter as Router, Route, Link, Switch } from 'react-router-dom';
+import styled from 'styled-components';
+
+import List from '@views/List';
+import Calendar from '@views/Calendar';
+import Statistics from '@views/Statistics';
+
+const useStyles = makeStyles({
+  root: {
+    flexGrow: 1,
+  },
+});
+
+const Accountbook: React.FC = () => {
+  const classes = useStyles();
+  const [value, setValue] = React.useState(0);
+
+  const handleChange = (event: React.ChangeEvent<any>, newValue: number) => {
+    setValue(newValue);
+  };
+
+  const tabsStyle = {
+    backgroundColor: myColor.primary.main,
+  };
+
+  const MarginBox = styled.div`
+    width: 100%;
+    height: 2rem; {/* <TopNavBar /> */
+  `;
+
+  const tabStyle = {
+    textDecoration: 'none',
+    color: myColor.primary.black,
+  };
+
+  return (
+    <CenterContent>
+      <TopNavBar />
+      <MarginBox />
+      <Router>
+        <Paper className={classes.root}>
+          <Tabs value={value} onChange={handleChange} style={tabsStyle} centered>
+            <Link style={tabStyle} to="/accountbook/list" onClick={() => setValue(0)}>
+              <Tab label="내역" />
+            </Link>
+            <Link style={tabStyle} to="/accountbook/calendar" onClick={() => setValue(1)}>
+              <Tab label="달력" />
+            </Link>
+            <Link style={tabStyle} to="/accountbook/statistics" onClick={() => setValue(2)}>
+              <Tab label="통계" />
+            </Link>
+          </Tabs>
+        </Paper>
+        <Switch>
+          <Route path="/accountbook/list" component={List} />
+          <Route path="/accountbook/calendar" component={Calendar} />
+          <Route path="/accountbook/statistics" component={Statistics} />
+        </Switch>
+      </Router>
+    </CenterContent>
+  );
+};
+
+export default Accountbook;

--- a/client/src/views/Accountbook.tsx
+++ b/client/src/views/Accountbook.tsx
@@ -6,7 +6,7 @@ import Tab from '@material-ui/core/Tab';
 import myColor from '@theme/color';
 import TopNavBar from '@organisms/TopNavBar';
 import CenterContent from '@molecules/CenterContent';
-import { BrowserRouter as Router, Route, Link, Switch } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Link, Switch, Redirect } from 'react-router-dom';
 import styled from 'styled-components';
 
 import List from '@views/List';
@@ -63,6 +63,7 @@ const Accountbook: React.FC = () => {
           <Route path="/accountbook/list" component={List} />
           <Route path="/accountbook/calendar" component={Calendar} />
           <Route path="/accountbook/statistics" component={Statistics} />
+          <Redirect from="*" to="/accountbook/list" />
         </Switch>
       </Router>
     </CenterContent>

--- a/client/src/views/Calendar.tsx
+++ b/client/src/views/Calendar.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CenteredTabs: React.FC = () => {
+  return <div>this is calendar page</div>;
+};
+
+export default CenteredTabs;

--- a/client/src/views/List.tsx
+++ b/client/src/views/List.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CenteredTabs: React.FC = () => {
+  return <div>this is list Page</div>;
+};
+
+export default CenteredTabs;

--- a/client/src/views/Statistics.tsx
+++ b/client/src/views/Statistics.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const CenteredTabs: React.FC = () => {
+  return <div>this is statistics page</div>;
+};
+
+export default CenteredTabs;


### PR DESCRIPTION
### 📕 Issue Number

Close #53 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 상단 tab 메뉴 구현
<img width="412" alt="스크린샷 2020-12-02 오후 6 42 57" src="https://user-images.githubusercontent.com/55074799/100856006-33afd200-34ce-11eb-8ac9-b1ce75ba0c6d.png">

- 클릭시 컨텐츠 영역 변경되도록 구현
![Dec-02-2020 18-44-00](https://user-images.githubusercontent.com/55074799/100856216-7c678b00-34ce-11eb-9b6f-a9ba12930d04.gif)

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 맨 위쪽 상단바의 라우팅은 어떻게 해줘야할지 고민이네요
- material-ui를 적용했는데 확실히 생산성이 좋은것 같습니다
- atoms를 미리 만들어두었다고 생각하고 page에서 조합했는데 이렇게 해도 되는지 고민이네요

<br/><br/>