### PR TITLE
BE-feat-social-api 소셜 가계부 목록 조회 API 구현

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -1,7 +1,10 @@
-import { Context } from 'koa';
 import 'dotenv/config';
 import oauthRouter from './src/oauth/router';
 import verifyToken from './src/middleware/verifyToken';
+import apiRouter from './src/router';
+
+const Router = require('koa-router');
+const router = new Router();
 
 const Koa = require('koa');
 const bodyParser = require('koa-bodyparser');
@@ -11,7 +14,10 @@ const app = new Koa();
 
 app.use(cors());
 app.use(bodyParser());
-app.use(oauthRouter.routes());
-app.use(verifyToken);
-app.listen(3000);
 
+app.use(oauthRouter.routes());
+app.use(router.routes());
+app.use(router.allowedMethods());
+router.use('/api', verifyToken, apiRouter.routes());
+
+app.listen(3000);

--- a/server/src/interface/social.ts
+++ b/server/src/interface/social.ts
@@ -1,0 +1,23 @@
+type picture = string;
+
+type userImages = picture[];
+
+type socialBookId = number;
+
+export interface UserImage {
+  picture: picture;
+}
+
+export interface SocialBookId {
+  accountbook_id: socialBookId;
+}
+
+export interface SocialInfo {
+  id: socialBookId;
+  name: string;
+  description: string;
+  color: string;
+  incomeSum: string;
+  expenditureSum: string;
+  images?: userImages;
+}

--- a/server/src/interface/user.ts
+++ b/server/src/interface/user.ts
@@ -8,6 +8,7 @@ interface OauthUserData {
   name: string;
   id: string;
   oAuthOrigin?: string;
+  uid?: string;
 }
 
 interface InsertUser {

--- a/server/src/middleware/verifyToken.ts
+++ b/server/src/middleware/verifyToken.ts
@@ -16,7 +16,7 @@ const verifyToken = async (ctx: Context, next: any) => {
   try {
     const decoded: OauthUserData = await jwt.verify(token, process.env.JWT_SECRET);
     ctx.userData = decoded;
-    next();
+    await next();
   } catch (err) {
     ctx.body = { link: `${process.env.LOGIN_URL as string}` };
     ctx.status = 401;

--- a/server/src/middleware/verifyToken.ts
+++ b/server/src/middleware/verifyToken.ts
@@ -4,7 +4,7 @@ import { OauthUserData } from '../interface/user';
 const jwt = require('jsonwebtoken');
 
 const verifyToken = async (ctx: Context, next: any) => {
-  const token = ctx.header.token;
+  const { token } = ctx.header;
 
   ctx.type = 'application/json';
   if (token === 'undefined') {

--- a/server/src/model/query/index.ts
+++ b/server/src/model/query/index.ts
@@ -1,8 +1,10 @@
 import privateBookQuery from './privateBookQuery';
 import userQuery from './userQuery';
+import socialBookQuery from './socialBookQuery';
 
 const query = {
   ...privateBookQuery,
   ...userQuery,
+  ...socialBookQuery,
 };
 export default query;

--- a/server/src/model/query/socialBookQuery.ts
+++ b/server/src/model/query/socialBookQuery.ts
@@ -1,0 +1,33 @@
+const socialBookQuery = {
+  READ_SOCIAL_BOOK_LIST: `SELECT accountbook_id FROM social_accountbook_users WHERE user_id = ? AND state = 2;`,
+  READ_SOCIAL_BOOK: `
+      SELECT id, name, description, color,
+      (SELECT SUM(amount)
+      FROM social_transaction AS transaction
+      WHERE accountbook.id = transaction.accountbook_id 
+      AND transaction.date > LAST_DAY(NOW() - interval 1 month) AND transaction.date <= LAST_DAY(NOW())
+      AND transaction.payment_id IS NULL) AS incomeSum,
+      (SELECT SUM(amount)
+      FROM social_transaction AS transaction
+      WHERE accountbook.id = transaction.accountbook_id
+      AND transaction.date > LAST_DAY(NOW() - interval 1 month) AND transaction.date <= LAST_DAY(NOW())
+      AND transaction.payment_id IS NOT NULL) AS expenditureSum
+      FROM social_accountbook AS accountbook
+      WHERE id IN (?);`,
+  READ_SOCIAL_BOOK_MASTER: `
+      SELECT id, name, description, color,
+      (SELECT SUM(amount)
+      FROM social_transaction AS transaction
+      WHERE accountbook.id = transaction.accountbook_id 
+      AND transaction.date > LAST_DAY(NOW() - interval 1 month) AND transaction.date <= LAST_DAY(NOW())
+      AND transaction.payment_id IS NULL) AS incomeSum,
+      (SELECT SUM(amount)
+      FROM social_transaction AS transaction
+      WHERE accountbook.id = transaction.accountbook_id
+      AND transaction.date > LAST_DAY(NOW() - interval 1 month) AND transaction.date <= LAST_DAY(NOW())
+      AND transaction.payment_id IS NOT NULL) AS expenditureSum
+      FROM social_accountbook AS accountbook
+      WHERE master_id = ?;`,
+};
+
+export default socialBookQuery;

--- a/server/src/model/query/socialBookQuery.ts
+++ b/server/src/model/query/socialBookQuery.ts
@@ -1,33 +1,37 @@
 const socialBookQuery = {
   READ_SOCIAL_BOOK_LIST: `SELECT accountbook_id FROM social_accountbook_users WHERE user_id = ? AND state = 2;`,
   READ_SOCIAL_BOOK: `
-      SELECT id, name, description, color,
-      (SELECT SUM(amount)
-      FROM social_transaction AS transaction
-      WHERE accountbook.id = transaction.accountbook_id 
-      AND transaction.date > LAST_DAY(NOW() - interval 1 month) AND transaction.date <= LAST_DAY(NOW())
-      AND transaction.payment_id IS NULL) AS incomeSum,
-      (SELECT SUM(amount)
-      FROM social_transaction AS transaction
-      WHERE accountbook.id = transaction.accountbook_id
-      AND transaction.date > LAST_DAY(NOW() - interval 1 month) AND transaction.date <= LAST_DAY(NOW())
-      AND transaction.payment_id IS NOT NULL) AS expenditureSum
-      FROM social_accountbook AS accountbook
-      WHERE id IN (?);`,
+    SELECT id, name, description, color,
+    (SELECT SUM(amount)
+    FROM social_transaction AS transaction
+    WHERE accountbook.id = transaction.accountbook_id 
+    AND transaction.date > LAST_DAY(NOW() - interval 1 month) AND transaction.date <= LAST_DAY(NOW())
+    AND transaction.payment_id IS NULL) AS incomeSum,
+    (SELECT SUM(amount)
+    FROM social_transaction AS transaction
+    WHERE accountbook.id = transaction.accountbook_id
+    AND transaction.date > LAST_DAY(NOW() - interval 1 month) AND transaction.date <= LAST_DAY(NOW())
+    AND transaction.payment_id IS NOT NULL) AS expenditureSum
+    FROM social_accountbook AS accountbook
+    WHERE id IN (?);`,
   READ_SOCIAL_BOOK_MASTER: `
-      SELECT id, name, description, color,
-      (SELECT SUM(amount)
-      FROM social_transaction AS transaction
-      WHERE accountbook.id = transaction.accountbook_id 
-      AND transaction.date > LAST_DAY(NOW() - interval 1 month) AND transaction.date <= LAST_DAY(NOW())
-      AND transaction.payment_id IS NULL) AS incomeSum,
-      (SELECT SUM(amount)
-      FROM social_transaction AS transaction
-      WHERE accountbook.id = transaction.accountbook_id
-      AND transaction.date > LAST_DAY(NOW() - interval 1 month) AND transaction.date <= LAST_DAY(NOW())
-      AND transaction.payment_id IS NOT NULL) AS expenditureSum
-      FROM social_accountbook AS accountbook
-      WHERE master_id = ?;`,
+    SELECT id, name, description, color,
+    (SELECT SUM(amount)
+    FROM social_transaction AS transaction
+    WHERE accountbook.id = transaction.accountbook_id 
+    AND transaction.date > LAST_DAY(NOW() - interval 1 month) AND transaction.date <= LAST_DAY(NOW())
+    AND transaction.payment_id IS NULL) AS incomeSum,
+    (SELECT SUM(amount)
+    FROM social_transaction AS transaction
+    WHERE accountbook.id = transaction.accountbook_id
+    AND transaction.date > LAST_DAY(NOW() - interval 1 month) AND transaction.date <= LAST_DAY(NOW())
+    AND transaction.payment_id IS NOT NULL) AS expenditureSum
+    FROM social_accountbook AS accountbook
+    WHERE master_id = ?;`,
+  READ_SOCIAL_BOOK_USER_IMAGES: `
+    SELECT picture FROM users WHERE id IN
+    (SELECT user_id FROM social_accountbook_users WHERE (state = 0 OR state = 2) AND accountbook_id = ?)
+    LIMIT 3;`,
 };
 
 export default socialBookQuery;

--- a/server/src/oauth/controller.ts
+++ b/server/src/oauth/controller.ts
@@ -53,8 +53,6 @@ const oauth = async (ctx: any) => {
 
   const data = await Service.getOAuthUserData(user_url, token, token_type);
 
-  const jwtToken = Service.createJWTtoken(data, site);
-
   const userData: InsertUser = {
     pid: data.id,
     email: data.email,
@@ -66,10 +64,16 @@ const oauth = async (ctx: any) => {
     oAuthOrigin: site,
   };
 
-  if (!(await Service.findUser(userData))) {
-    const userId = await Service.insertUser(userData);
+  let userId = await Service.findUser(userData);
+
+  if (userId === undefined) {
+    userId = await Service.insertUser(userData);
     await Service.createPrivateAccountbook(userId);
   }
+
+  data.uid = userId;
+
+  const jwtToken = Service.createJWTtoken(data, site);
 
   ctx.body = jwtToken;
 };

--- a/server/src/oauth/controller.ts
+++ b/server/src/oauth/controller.ts
@@ -66,7 +66,7 @@ const oauth = async (ctx: any) => {
 
   let userId = await Service.findUser(userData);
 
-  if (userId === undefined) {
+  if (!userId) {
     userId = await Service.insertUser(userData);
     await Service.createPrivateAccountbook(userId);
   }

--- a/server/src/oauth/service.ts
+++ b/server/src/oauth/service.ts
@@ -8,7 +8,7 @@ const axios = require('axios').default;
 
 const createJWTtoken = (data: OauthUserData, site: string) => {
   const jwtToken = jwt.sign(
-    { login: data.name, id: data.id, oAuthOrigin: site },
+    { login: data.name, id: data.id, oAuthOrigin: site, uid: data.uid },
     process.env.JWT_SECRET,
     {
       expiresIn: '1d',
@@ -63,8 +63,15 @@ const findUser = async (props: SelectUser) => {
   const { pid, oAuthOrigin } = props;
 
   const [result] = await sql(query.READ_USER, [pid, oAuthOrigin]);
-  return result !== undefined;
+  return result === undefined ? undefined : result.id;
 };
+
+// const findUserId = async (props: SelectUser) => {
+//   const { pid, oAuthOrigin } = props;
+
+//   const [result] = await sql(query.READ_USER, [pid, oAuthOrigin]);
+//   return result.id;
+// };
 
 const createPrivateAccountbook = async (userId: number) => {
   await sql(query.CREATE_PRIVATE_BOOK, [userId, '내 가계부', '', '#F4C239']);

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -3,6 +3,6 @@ import socialBookRouter from './socialBook/router';
 const Router = require('koa-router');
 const router = new Router();
 
-router.use('/accountbook', socialBookRouter.routes());
+router.use('/social', socialBookRouter.routes());
 
 export default router;

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -1,0 +1,8 @@
+import socialBookRouter from './socialBook/router';
+
+const Router = require('koa-router');
+const router = new Router();
+
+router.use('/accountbook', socialBookRouter.routes());
+
+export default router;

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -4,13 +4,13 @@ import 'dotenv/config';
 import * as Service from './service';
 
 export const getSocialBooks = async (ctx: Context) => {
-  const userId = 18; // TODO : jwtToken 수정 후 고치기
+  const userId = ctx.userData.uid; // TODO : jwtToken 수정 후 고치기
   const result = await Service.getSocialBooks(userId);
   response.success(ctx, result);
 };
 
 export const getSocialBooksMaster = async (ctx: Context) => {
-  const userId = 11; // TODO : jwtToken 수정 후 고치기
+  const userId = ctx.userData.uid; // TODO : jwtToken 수정 후 고치기
   const result = await Service.getSocialBooksMaster(userId);
   response.success(ctx, result);
 };

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -1,0 +1,16 @@
+import { Context } from 'koa';
+import * as response from '../utils/response';
+import 'dotenv/config';
+import * as Service from './service';
+
+export const getSocialBooks = async (ctx: Context) => {
+  const userId = 18; // TODO : jwtToken 수정 후 고치기
+  const result = await Service.getSocialBooks(userId);
+  response.success(ctx, result);
+};
+
+export const getSocialBooksMaster = async (ctx: Context) => {
+  const userId = 11; // TODO : jwtToken 수정 후 고치기
+  const result = await Service.getSocialBooksMaster(userId);
+  response.success(ctx, result);
+};

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -4,13 +4,15 @@ import 'dotenv/config';
 import * as Service from './service';
 
 export const getSocialBooks = async (ctx: Context) => {
-  const userId = ctx.userData.uid; // TODO : jwtToken 수정 후 고치기
-  const result = await Service.getSocialBooks(userId);
+  const userId = ctx.userData.uid;
+  const socialBookResult = await Service.getSocialBooks(userId);
+  const result = await Service.getUserImages(socialBookResult);
   response.success(ctx, result);
 };
 
 export const getSocialBooksMaster = async (ctx: Context) => {
-  const userId = ctx.userData.uid; // TODO : jwtToken 수정 후 고치기
-  const result = await Service.getSocialBooksMaster(userId);
+  const userId = ctx.userData.uid;
+  const socialBookResult = await Service.getSocialBooksMaster(userId);
+  const result = await Service.getUserImages(socialBookResult);
   response.success(ctx, result);
 };

--- a/server/src/socialBook/router.ts
+++ b/server/src/socialBook/router.ts
@@ -4,8 +4,8 @@ const Router = require('@koa/router');
 
 const router = new Router();
 
-router.get('/social', Controller.getSocialBooks);
+router.get('/list', Controller.getSocialBooks);
 
-router.get('/master', Controller.getSocialBooksMaster);
+router.get('/list/master', Controller.getSocialBooksMaster);
 
 export default router;

--- a/server/src/socialBook/router.ts
+++ b/server/src/socialBook/router.ts
@@ -1,0 +1,11 @@
+import * as Controller from './controller';
+
+const Router = require('@koa/router');
+
+const router = new Router();
+
+router.get('/social', Controller.getSocialBooks);
+
+router.get('/master', Controller.getSocialBooksMaster);
+
+export default router;

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -1,0 +1,15 @@
+import 'dotenv/config';
+import sql from '../model/db';
+import query from '../model/query';
+
+export const getSocialBooks = async (userId: number) => {
+  const socialBookList = await sql(query.READ_SOCIAL_BOOK_LIST, [userId]);
+  const socialBookIdList = socialBookList.map((row: any) => row.accountbook_id);
+  const bookList = await sql(query.READ_SOCIAL_BOOK, [socialBookIdList]);
+  return bookList;
+};
+
+export const getSocialBooksMaster = async (userId: number) => {
+  const bookList = await sql(query.READ_SOCIAL_BOOK_MASTER, [userId]);
+  return bookList;
+};

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -1,10 +1,11 @@
 import 'dotenv/config';
 import sql from '../model/db';
 import query from '../model/query';
+import { UserImage, SocialInfo, SocialBookId } from '../interface/social';
 
 export const getSocialBooks = async (userId: number) => {
   const socialBookList = await sql(query.READ_SOCIAL_BOOK_LIST, [userId]);
-  const socialBookIdList = socialBookList.map((row: any) => row.accountbook_id);
+  const socialBookIdList = socialBookList.map((row: SocialBookId) => row.accountbook_id);
   const bookList = await sql(query.READ_SOCIAL_BOOK, [socialBookIdList]);
   return bookList;
 };
@@ -16,13 +17,13 @@ export const getSocialBooksMaster = async (userId: number) => {
 
 export const getSocialBookUserImages = async (accountBookId: number) => {
   const imageList = await sql(query.READ_SOCIAL_BOOK_USER_IMAGES, [accountBookId]);
-  const imageArray = imageList.map((row: any) => row.picture);
+  const imageArray = imageList.map((row: UserImage) => row.picture);
   return imageArray;
 };
 
-export const getUserImages = async (socialBookList: any) => {
+export const getUserImages = async (socialBookList: SocialInfo[]) => {
   await Promise.all(
-    socialBookList.map(async (socialBook: any) => {
+    socialBookList.map(async (socialBook: SocialInfo) => {
       const userImages = await getSocialBookUserImages(socialBook.id);
       socialBook.images = userImages;
       return socialBook;

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -13,3 +13,20 @@ export const getSocialBooksMaster = async (userId: number) => {
   const bookList = await sql(query.READ_SOCIAL_BOOK_MASTER, [userId]);
   return bookList;
 };
+
+export const getSocialBookUserImages = async (accountBookId: number) => {
+  const imageList = await sql(query.READ_SOCIAL_BOOK_USER_IMAGES, [accountBookId]);
+  const imageArray = imageList.map((row: any) => row.picture);
+  return imageArray;
+};
+
+export const getUserImages = async (socialBookList: any) => {
+  await Promise.all(
+    socialBookList.map(async (socialBook: any) => {
+      const userImages = await getSocialBookUserImages(socialBook.id);
+      socialBook.images = userImages;
+      return socialBook;
+    }),
+  );
+  return socialBookList;
+};

--- a/server/src/utils/response.ts
+++ b/server/src/utils/response.ts
@@ -1,0 +1,25 @@
+import { Context } from 'koa';
+
+export const success = (ctx: Context, result: any) => {
+  ctx.status = 200;
+  ctx.body = {
+    status: 'success',
+    data: result,
+  };
+};
+
+export const fail = (ctx: Context, status: number, result: any) => {
+  ctx.status = status;
+  ctx.body = {
+    status: 'fail',
+    data: result,
+  };
+};
+
+export const unAuthorized = (ctx: Context, result: any) => {
+  ctx.status = 401;
+  ctx.body = {
+    status: 'unAuthorized',
+    data: result,
+  };
+};


### PR DESCRIPTION
### 📕 Issue Number

Close #49 #13 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 내가 속한 소셜가계부 목록
> http://localhost:3000/api/social/list
```json
{
    "status": "success",
    "data": [
        {
            "id": 2,
            "name": "제구월드",
            "description": "밥.좋.아.",
            "color": "#8baf6b",
            "incomeSum": "5016551",
            "expenditureSum": "9344",
            "images": [
                "https://avatars2.githubusercontent.com/u/55074799?v=4",
                "https://avatars1.githubusercontent.com/u/46099115?v=4",
                "https://avatars2.githubusercontent.com/u/50297117?v=4"
            ]
        }
    ]
}
```

- 내가 master인 소셜가계부 목록
> http://localhost:3000/api/social/list/master
```json
{
    "status": "success",
    "data": [
        {
            "id": 1,
            "name": "부캠 가계부",
            "description": "동아리 가계부 입니다",
            "color": "#121212",
            "incomeSum": "170000",
            "expenditureSum": "112150",
            "images": [
                "https://avatars2.githubusercontent.com/u/50297117?v=4",
                "https://avatars2.githubusercontent.com/u/55074799?v=4"
            ]
        },
        {
            "id": 4,
            "name": "가계부2",
            "description": "설명 없음",
            "color": "#111111",
            "incomeSum": null,
            "expenditureSum": null,
            "images": [
                "https://avatars2.githubusercontent.com/u/55074799?v=4"
            ]
        }
    ]
}
```

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- api router를 분리하고 verifyToken 을 middleware로 지정해주었습니다.
<br/><br/>