### PR TITLE
FE-feat-날짜별 가계부 내역 상세 조회기능 구현

### DIFF
--- a/client/src/components/atoms/div/RoundShortChips/RoundShortChips.tsx
+++ b/client/src/components/atoms/div/RoundShortChips/RoundShortChips.tsx
@@ -12,6 +12,7 @@ interface ChipsProps {
   width?: string;
   height?: string;
   fontSize?: string;
+  margin?: string;
 }
 
 const defaultProps = {
@@ -20,6 +21,7 @@ const defaultProps = {
   width: '4rem',
   height: '1.5rem',
   fontSize: '0.8rem',
+  margin: 'none',
 };
 
 const Chips = styled.div<ChipsProps>`
@@ -33,6 +35,7 @@ const Chips = styled.div<ChipsProps>`
   background-color: ${(props) => props.backgroundColor};
   color: ${(props) => props.color};
   border-radius: 10px;
+  margin: ${(props) => props.margin};
 `;
 
 const RoundShortChips: React.FC<Props> = ({
@@ -42,6 +45,7 @@ const RoundShortChips: React.FC<Props> = ({
   fontSize,
   color,
   children,
+  margin,
 }: Props) => {
   return (
     <Chips
@@ -50,6 +54,7 @@ const RoundShortChips: React.FC<Props> = ({
       height={height}
       fontSize={fontSize}
       color={color}
+      margin={margin}
     >
       {children}
     </Chips>

--- a/client/src/components/atoms/div/RowFlexContainer/RowFlexContainer.tsx
+++ b/client/src/components/atoms/div/RowFlexContainer/RowFlexContainer.tsx
@@ -5,8 +5,9 @@ interface Props {
   justifyContent?: string;
   alignContent?: string;
   alignItems?: string;
-  children: React.ReactChild | React.ReactChild[];
+  children?: React.ReactChild | React.ReactChild[];
   margin?: string;
+  padding?: string;
   width?: string;
   height?: string;
   flexWrap?: string;
@@ -24,6 +25,8 @@ const defaultProps = {
   flexWrap: 'nowrap',
   borderWidth: '',
   borderStyle: '',
+  children: '',
+  padding: '0',
 };
 
 const Div = styled.div<Props>`
@@ -33,6 +36,7 @@ const Div = styled.div<Props>`
   align-content: ${(props) => props.alignContent};
   align-items: ${(props) => props.alignItems};
   margin: ${(props) => props.margin};
+  padding: ${(props) => props.padding};
   width: ${(props) => props.width};
   height: ${(props) => props.height};
   flex-wrap: ${(props) => props.flexWrap};

--- a/client/src/components/atoms/div/RowFlexContainer/RowFlexContainer.tsx
+++ b/client/src/components/atoms/div/RowFlexContainer/RowFlexContainer.tsx
@@ -10,6 +10,8 @@ interface Props {
   width?: string;
   height?: string;
   flexWrap?: string;
+  borderWidth?: string;
+  borderStyle?: string;
 }
 
 const defaultProps = {
@@ -20,6 +22,8 @@ const defaultProps = {
   width: '',
   height: '',
   flexWrap: 'nowrap',
+  borderWidth: '',
+  borderStyle: '',
 };
 
 const Div = styled.div<Props>`
@@ -32,6 +36,8 @@ const Div = styled.div<Props>`
   width: ${(props) => props.width};
   height: ${(props) => props.height};
   flex-wrap: ${(props) => props.flexWrap};
+  border-width: ${(props) => props.borderWidth};
+  border-style: ${(props) => props.borderStyle};
 `;
 
 const RowFlexContainer: React.FC<Props> = ({ children, ...props }: Props) => {

--- a/client/src/components/molecules/TransactionInfo/TransactionInfo.stories.tsx
+++ b/client/src/components/molecules/TransactionInfo/TransactionInfo.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import TransactionInfo from './TransactionInfo';
+
+export default {
+  title: 'Molecules/TransactionInfo',
+  component: TransactionInfo,
+};
+
+const data = {
+  category: '식비',
+  payment: null,
+  title: '맥도날드',
+  amount: 20000,
+};
+
+export const transactionInfo = (): JSX.Element => {
+  return <TransactionInfo data={data} />;
+};
+
+transactionInfo.story = {
+  name: 'TransactionInfo',
+};

--- a/client/src/components/molecules/TransactionInfo/TransactionInfo.tsx
+++ b/client/src/components/molecules/TransactionInfo/TransactionInfo.tsx
@@ -27,6 +27,7 @@ const TransactionInfo: React.FC<props> = ({ data }: props) => {
       alignItems="center"
       borderWidth="0px 0px 0.5px 0px"
       borderStyle="solid"
+      padding="5px 0px 5px 0px"
     >
       <RowFlexContainer>
         <RoundShortChips
@@ -39,14 +40,14 @@ const TransactionInfo: React.FC<props> = ({ data }: props) => {
         <LeftNormalText>{data.title}</LeftNormalText>
       </RowFlexContainer>
       {data.payment === null ? (
-        <ExpenditureText
+        <IncomeText
           money={data.amount}
           fontSize="1rem"
           fontWeight="normal"
           color={myColor.primary.main}
         />
       ) : (
-        <IncomeText
+        <ExpenditureText
           money={data.amount}
           fontSize="1rem"
           fontWeight="normal"

--- a/client/src/components/molecules/TransactionInfo/TransactionInfo.tsx
+++ b/client/src/components/molecules/TransactionInfo/TransactionInfo.tsx
@@ -27,7 +27,7 @@ const TransactionInfo: React.FC<props> = ({ data }: props) => {
       alignItems="center"
       borderWidth="0px 0px 0.5px 0px"
       borderStyle="solid"
-      padding="5px 0px 5px 0px"
+      padding="8px 0px 8px 0px"
     >
       <RowFlexContainer>
         <RoundShortChips

--- a/client/src/components/molecules/TransactionInfo/TransactionInfo.tsx
+++ b/client/src/components/molecules/TransactionInfo/TransactionInfo.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import RowFlexContainer from '@atoms/div/RowFlexContainer';
+import RoundShortChips from '@atoms/div/RoundShortChips';
+import LeftNormalText from '@atoms/p/LeftNormalText';
+import ntm from '@utils/numberToMoney';
+import myColor from '@theme/color';
+import ExpenditureText from '@atoms/p/ExpenditureText';
+import IncomeText from '@atoms/p/IncomeText';
+
+interface props {
+  data: dataProps;
+}
+
+interface dataProps {
+  category: string;
+  title: string;
+  amount: number;
+  payment: any;
+}
+
+const TransactionInfo: React.FC<props> = ({ data }: props) => {
+  return (
+    <RowFlexContainer
+      width="100%"
+      height="2rem"
+      justifyContent="space-between"
+      alignItems="center"
+      borderWidth="0px 0px 0.5px 0px"
+      borderStyle="solid"
+    >
+      <RowFlexContainer>
+        <RoundShortChips
+          backgroundColor={data.payment === null ? myColor.primary.main : myColor.primary.accent}
+          margin="0px 10px 0px 0px"
+        >
+          {data.category}
+        </RoundShortChips>
+
+        <LeftNormalText>{data.title}</LeftNormalText>
+      </RowFlexContainer>
+      {data.payment === null ? (
+        <ExpenditureText
+          money={data.amount}
+          fontSize="1rem"
+          fontWeight="normal"
+          color={myColor.primary.main}
+        />
+      ) : (
+        <IncomeText
+          money={data.amount}
+          fontSize="1rem"
+          fontWeight="normal"
+          color={myColor.primary.accent}
+        />
+      )}
+    </RowFlexContainer>
+  );
+};
+
+export default TransactionInfo;

--- a/client/src/components/molecules/TransactionInfo/index.ts
+++ b/client/src/components/molecules/TransactionInfo/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TransactionInfo';

--- a/client/src/components/molecules/TransactionTotal/TransactionTotal.stories.tsx
+++ b/client/src/components/molecules/TransactionTotal/TransactionTotal.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import TransactionTotal from './TransactionTotal';
+
+export default {
+  title: 'Molecules/TransactionTotal',
+  component: TransactionTotal,
+};
+
+const data = {
+  expenditure: 5000000,
+  income: 39800,
+};
+
+export const transactionTotal = (): JSX.Element => {
+  return <TransactionTotal data={data} />;
+};
+
+transactionTotal.story = {
+  name: 'TransactionTotal',
+};

--- a/client/src/components/molecules/TransactionTotal/TransactionTotal.tsx
+++ b/client/src/components/molecules/TransactionTotal/TransactionTotal.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import RowFlexContainer from '@atoms/div/RowFlexContainer';
+import myColor from '@theme/color';
+import ExpenditureText from '@atoms/p/ExpenditureText';
+import IncomeText from '@atoms/p/IncomeText';
+
+interface props {
+  data: dataProps;
+}
+
+interface dataProps {
+  expenditure: number;
+  income: number;
+}
+
+const TransactionTotal: React.FC<props> = ({ data }: props) => {
+  return (
+    <RowFlexContainer
+      width="100%"
+      height="2rem"
+      justifyContent="flex-end"
+      alignItems="center"
+      borderWidth="0px 0px 2px 0px"
+      borderStyle="solid"
+    >
+      <ExpenditureText
+        money={data.expenditure}
+        fontSize="1rem"
+        fontWeight="normal"
+        color={myColor.primary.accent}
+      />
+      <RowFlexContainer width="10px" />
+      <IncomeText
+        money={data.income}
+        fontSize="1rem"
+        fontWeight="normal"
+        color={myColor.primary.main}
+      />
+    </RowFlexContainer>
+  );
+};
+
+export default TransactionTotal;

--- a/client/src/components/molecules/TransactionTotal/index.ts
+++ b/client/src/components/molecules/TransactionTotal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TransactionTotal';

--- a/client/src/components/organisms/DailyTransactionModal/DailyTransactionModal.stories.tsx
+++ b/client/src/components/organisms/DailyTransactionModal/DailyTransactionModal.stories.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import DailyTransactionModal from './DailyTransactionModal';
+
+export default {
+  title: 'Organisms/DailyTransactionModal',
+  component: DailyTransactionModal,
+};
+const title = '18일 (수)';
+
+const data = [
+  {
+    category: '식비',
+    payment: '현대카드',
+    title: '맥도날드',
+    amount: 20000,
+  },
+  {
+    category: '월급',
+    payment: null,
+    title: '부스트캠프',
+    amount: 50000000,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '택시비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '밥값',
+    amount: 15360,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+  {
+    category: '생활',
+    payment: '현대카드',
+    title: '버스비',
+    amount: 39800,
+  },
+];
+
+export const dailyTransactionModal = (): JSX.Element => {
+  return <DailyTransactionModal title={title} data={data} />;
+};
+
+dailyTransactionModal.story = {
+  name: 'DailyTransactionModal',
+};

--- a/client/src/components/organisms/DailyTransactionModal/DailyTransactionModal.tsx
+++ b/client/src/components/organisms/DailyTransactionModal/DailyTransactionModal.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Modal from '@molecules/Modal';
+import styled from 'styled-components';
+import TransactionTotal from '@molecules/TransactionTotal';
+import TransactionInfo from '@molecules/TransactionInfo';
+
+interface props {
+  data: any;
+  title: string;
+}
+
+const ScrollDiv = styled.div`
+  display: flex;
+  flex-flow: column;
+  width: 100%;
+  height: 80%;
+  overflow: scroll;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const DailyTransactionModal: React.FC<props> = ({ data, title }: props) => {
+  const transactionList = data.map((curr) => {
+    return <TransactionInfo data={curr} />;
+  });
+
+  let expend = 0;
+  let income = 0;
+
+  data.forEach((transaction) => {
+    transaction.payment === null ? (income += transaction.amount) : (expend += transaction.amount);
+  });
+
+  return (
+    <Modal title={title}>
+      <TransactionTotal data={{ expenditure: expend, income }} />
+      <ScrollDiv>{transactionList}</ScrollDiv>
+    </Modal>
+  );
+};
+
+export default DailyTransactionModal;

--- a/client/src/components/organisms/DailyTransactionModal/index.ts
+++ b/client/src/components/organisms/DailyTransactionModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DailyTransactionModal';


### PR DESCRIPTION
### 📕 Issue Number

Close #55 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

![image](https://user-images.githubusercontent.com/55074799/101039633-3dfdc900-35bf-11eb-9e87-4ffb98cd3c7d.png)

![image](https://user-images.githubusercontent.com/55074799/101039529-36d6bb00-35bf-11eb-8087-0d1586333618.png)

![image](https://user-images.githubusercontent.com/55074799/101039382-2d4d5300-35bf-11eb-9871-db1eed8098c7.png)
![image](https://user-images.githubusercontent.com/55074799/101039228-245c8180-35bf-11eb-81a6-d6533a73d617.png)

- 스크롤 박스 적용
![image](https://user-images.githubusercontent.com/55074799/101042751-dea0b880-35c0-11eb-91cf-79632462b667.gif)


- atoms/div
  - RowFlexContainer : borderWidth, borderStyle 속성 추가, children을 필수에서 선택으로 변경
  - RoundShortChips : margin 속성 추가

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 리펙토링

<br/>

### 하고싶은 말
주말에는 리팩토링과 리덕스 학습을 달려보겠습니다