### PR TITLE
FE-feat-logout 구현

### DIFF
--- a/client/src/components/atoms/button/TextButton/TextButton.tsx
+++ b/client/src/components/atoms/button/TextButton/TextButton.tsx
@@ -4,7 +4,7 @@ import myColor from '@theme/color';
 
 interface Props {
   color?: string;
-  children: React.ReactChild;
+  children: React.ReactChild | React.ReactChild[];
   onClick?: () => void;
 }
 

--- a/client/src/components/organisms/MyPageUserMenu/MyPageUserMenu.tsx
+++ b/client/src/components/organisms/MyPageUserMenu/MyPageUserMenu.tsx
@@ -20,7 +20,7 @@ const ButtonContainer = styled.div`
 
 const MyPageUserMenu: React.FC<Props> = ({ name, profile }: Props) => {
   const deleteJWT = () => {
-    localStorage.clear();
+    localStorage.removeItem('jwt');
   };
   return (
     <RowFlexContainer margin="48px 20px 0px">

--- a/client/src/components/organisms/MyPageUserMenu/MyPageUserMenu.tsx
+++ b/client/src/components/organisms/MyPageUserMenu/MyPageUserMenu.tsx
@@ -7,6 +7,7 @@ import Logout from '@atoms/button/TextButton';
 import Span from '@atoms/span/BoldSpan';
 import P from '@atoms/p/LeftNormalText';
 import myColor from '@theme/color';
+import { Link } from 'react-router-dom';
 
 interface Props {
   name: string;
@@ -18,6 +19,9 @@ const ButtonContainer = styled.div`
 `;
 
 const MyPageUserMenu: React.FC<Props> = ({ name, profile }: Props) => {
+  const deleteJWT = () => {
+    localStorage.clear();
+  };
   return (
     <RowFlexContainer margin="48px 20px 0px">
       <UserImage link={profile} />
@@ -28,8 +32,10 @@ const MyPageUserMenu: React.FC<Props> = ({ name, profile }: Props) => {
         <P>안녕하세요</P>
       </ColumnFlexContainer>
       <ButtonContainer>
-        <Logout color={myColor.primary.black}>
-          <Span>로그아웃</Span>
+        <Logout onClick={deleteJWT} color={myColor.primary.black}>
+          <Link to="login">
+            <Span>로그아웃</Span>
+          </Link>
         </Logout>
       </ButtonContainer>
     </RowFlexContainer>


### PR DESCRIPTION
### 📕 Issue Number

Close #10 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 로그아웃 버튼클릭시 login page로 렌더링하며 로컬스토리지 토큰값 삭제

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 로그아웃을 backend에서도 관리 해야 할것인지 고민을 많이 했습니다.
  현재 저희의 구현을 토대로라면 Backend에서 관리할 방법이 없다고 판단했고, 브라우저에서 토큰의 유무를 가지고 인증 과정을 거치기 때문에
  Frontend에서 직접 로그아웃을 실행하는 것으로 구현했습니다.


<br/><br/>