### PR TITLE
Fe feat accountbook store

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import MyPage from '@views/MyPage';
 import CreateAccountbookPage from '@views/CreateAccountbookPage';
 import TransactionPostPage from '@views/TransactionPostPage';
 import AccountbookPage from '@views/AccountbookPage';
+import NotFoundPage from '@views/NotFoundPage';
 import GlobalStyle from '@shared/global';
 import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import { CookiesProvider } from 'react-cookie';
@@ -24,14 +25,14 @@ const App: React.FC = () => {
 
   const mainRouter = (
     <>
-      <Route exact path="/" component={MainPage} />
       <Switch>
         <Route path="/notification" component={NotificationPage} />
         <Route path="/mypage" component={MyPage} />
-        <Route path="/social-accountbook/new" component={CreateAccountbookPage} />
-        <Route path="/transaction/new" component={TransactionPostPage} />
+        <Route path="/accountbook/social/new" component={CreateAccountbookPage} />
+        <Route path="/accountbook/transaction/new" component={TransactionPostPage} />
         <Route path="/accountbook" component={AccountbookPage} />
-        <Redirect from="*" to="/" />
+        <Route exact path="/" component={MainPage} />
+        <Route path="/*" component={NotFoundPage} />
       </Switch>
     </>
   );

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,13 +9,23 @@ import AccountbookPage from '@views/AccountbookPage';
 import GlobalStyle from '@shared/global';
 import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import { CookiesProvider } from 'react-cookie';
+import { useSelector } from 'react-redux';
+import { RootState } from '@reducers/rootReducer';
 
 const App: React.FC = () => {
+  const login = useSelector((state: RootState) => state.user.isLogin);
+
+  const loginRouter = (
+    <>
+      <Route path="/login" component={LoginPage} />
+      <Redirect from="*" to="/login" />
+    </>
+  );
+
   const mainRouter = (
     <>
       <Route exact path="/" component={MainPage} />
       <Switch>
-        <Route path="/login" component={LoginPage} />
         <Route path="/notification" component={NotificationPage} />
         <Route path="/mypage" component={MyPage} />
         <Route path="/social-accountbook/new" component={CreateAccountbookPage} />
@@ -29,7 +39,7 @@ const App: React.FC = () => {
   return (
     <CookiesProvider>
       <BrowserRouter>
-        {mainRouter}
+        {login ? mainRouter : loginRouter}
         <GlobalStyle />
       </BrowserRouter>
     </CookiesProvider>

--- a/client/src/actions/accountbook/type.ts
+++ b/client/src/actions/accountbook/type.ts
@@ -1,0 +1,22 @@
+import { ActionProps } from '@interfaces/action';
+
+export const INIT_DATA = 'accountbook/INIT_DATA' as const;
+export const SET_PRIVATE = 'accountbook/SET_PRIVATE' as const;
+export const SET_SOCIAL = 'accountbook/SET_SOCIAL' as const;
+
+export const initData = (social: number[], privateId: number): ActionProps => ({
+  type: INIT_DATA,
+  payload: {
+    social,
+    private: privateId,
+  },
+});
+
+export const setPrivate = (): ActionProps => ({
+  type: SET_PRIVATE,
+});
+
+export const setSocial = (id: number): ActionProps => ({
+  type: SET_SOCIAL,
+  payload: id,
+});

--- a/client/src/actions/category/type.ts
+++ b/client/src/actions/category/type.ts
@@ -1,0 +1,7 @@
+import { ActionProps } from '@interfaces/action';
+
+export const GET_CATEGORY = 'category/GET_CATEGORY' as const;
+
+export const getCategory = (): ActionProps => ({
+  type: GET_CATEGORY,
+});

--- a/client/src/actions/user/type.ts
+++ b/client/src/actions/user/type.ts
@@ -1,0 +1,12 @@
+import { ActionProps } from '@interfaces/action';
+
+export const LOGIN = 'user/login' as const;
+export const LOGOUT = 'user/logout' as const;
+
+export const login = (): ActionProps => ({
+  type: LOGIN,
+});
+
+export const logout = (): ActionProps => ({
+  type: LOGOUT,
+});

--- a/client/src/components/organisms/MyPageUserMenu/MyPageUserMenu.tsx
+++ b/client/src/components/organisms/MyPageUserMenu/MyPageUserMenu.tsx
@@ -8,6 +8,8 @@ import Span from '@atoms/span/BoldSpan';
 import P from '@atoms/p/LeftNormalText';
 import myColor from '@theme/color';
 import { Link } from 'react-router-dom';
+import { logout } from '@actions/user/type';
+import { useDispatch } from 'react-redux';
 
 interface Props {
   name: string;
@@ -19,8 +21,11 @@ const ButtonContainer = styled.div`
 `;
 
 const MyPageUserMenu: React.FC<Props> = ({ name, profile }: Props) => {
+  const dispatch = useDispatch();
+
   const deleteJWT = () => {
     localStorage.removeItem('jwt');
+    dispatch(logout());
   };
   return (
     <RowFlexContainer margin="48px 20px 0px">

--- a/client/src/interfaces/category.ts
+++ b/client/src/interfaces/category.ts
@@ -1,0 +1,4 @@
+export interface Category {
+  id: number;
+  name: string;
+}

--- a/client/src/reducers/accountbook.ts
+++ b/client/src/reducers/accountbook.ts
@@ -1,0 +1,50 @@
+import {
+  INIT_DATA,
+  SET_PRIVATE,
+  SET_SOCIAL,
+  initData,
+  setPrivate,
+  setSocial,
+} from '@actions/accountbook/type';
+
+type AccountBookAction =
+  | ReturnType<typeof initData>
+  | ReturnType<typeof setPrivate>
+  | ReturnType<typeof setSocial>;
+
+type AccountBookState = {
+  type: string;
+  social: number[];
+  private: number;
+  now: number;
+};
+
+const initialState: AccountBookState = {
+  type: 'PRIVATE',
+  social: [],
+  private: 0,
+  now: 0,
+};
+
+const accountBook = (
+  state: AccountBookState = initialState,
+  action: AccountBookAction,
+): AccountBookState => {
+  switch (action.type) {
+    case INIT_DATA:
+      return {
+        type: 'PRIVATE',
+        social: action.payload.social,
+        private: action.payload.private,
+        now: 0,
+      };
+    case SET_PRIVATE:
+      return { type: 'PRIVATE', social: state.social, private: state.private, now: 0 };
+    case SET_SOCIAL:
+      return { type: 'SOCIAL', social: state.social, private: state.private, now: action.payload };
+    default:
+      return state;
+  }
+};
+
+export default accountBook;

--- a/client/src/reducers/category.ts
+++ b/client/src/reducers/category.ts
@@ -1,0 +1,45 @@
+import { GET_CATEGORY, getCategory } from '@actions/category/type';
+import { Category } from '@interfaces/category';
+import { getAxios } from '@utils/axios';
+import * as API from '@utils/api';
+
+type CategoryAction = ReturnType<typeof getCategory>;
+
+type CategoryState = {
+  income: Category[];
+  expenditure: Category[];
+};
+
+const getIncomeCategory = async () => {
+  const { data } = await getAxios(API.GET_INCOME_CATEGORY);
+  return data;
+};
+
+const getExpenditureCategory = async () => {
+  const { data } = await getAxios(API.GET_EXPENDITURE_CATEGORY);
+  return data;
+};
+
+const initCategory = async () => {
+  const income = await getIncomeCategory();
+  const expenditure = await getExpenditureCategory();
+  return { income, expenditure };
+};
+
+initCategory();
+
+const initialState = {
+  income: [],
+  expenditure: [],
+};
+
+const category = (state: CategoryState = initialState, action: CategoryAction): CategoryState => {
+  switch (action.type) {
+    case GET_CATEGORY:
+      return { income: state.income, expenditure: state.expenditure };
+    default:
+      return state;
+  }
+};
+
+export default category;

--- a/client/src/reducers/rootReducer.ts
+++ b/client/src/reducers/rootReducer.ts
@@ -1,12 +1,16 @@
 import { combineReducers } from 'redux';
+import user from './user';
 import modal from './modal';
 import date from './date';
 import accountbook from './accountbook';
+import category from './category';
 
 const rootReducer = combineReducers({
+  user,
   modal,
   date,
   accountbook,
+  category,
 });
 
 export default rootReducer;

--- a/client/src/reducers/rootReducer.ts
+++ b/client/src/reducers/rootReducer.ts
@@ -1,10 +1,12 @@
 import { combineReducers } from 'redux';
 import modal from './modal';
 import date from './date';
+import accountbook from './accountbook';
 
 const rootReducer = combineReducers({
   modal,
   date,
+  accountbook,
 });
 
 export default rootReducer;

--- a/client/src/reducers/user.ts
+++ b/client/src/reducers/user.ts
@@ -7,10 +7,7 @@ type UserState = {
 };
 
 const initIsLogin = () => {
-  if (localStorage.getItem('jwt')) {
-    return true;
-  }
-  return false;
+  return !!localStorage.getItem('jwt');
 };
 
 const initialState: UserState = {

--- a/client/src/reducers/user.ts
+++ b/client/src/reducers/user.ts
@@ -1,0 +1,31 @@
+import { LOGIN, LOGOUT, login, logout } from '@actions/user/type';
+
+type UserAction = ReturnType<typeof login> | ReturnType<typeof logout>;
+
+type UserState = {
+  isLogin: boolean;
+};
+
+const initIsLogin = () => {
+  if (localStorage.getItem('jwt')) {
+    return true;
+  }
+  return false;
+};
+
+const initialState: UserState = {
+  isLogin: initIsLogin(),
+};
+
+const user = (state: UserState = initialState, action: UserAction): UserState => {
+  switch (action.type) {
+    case LOGIN:
+      return { isLogin: true };
+    case LOGOUT:
+      return { isLogin: false };
+    default:
+      return state;
+  }
+};
+
+export default user;

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -3,3 +3,7 @@ import 'dotenv/config';
 export const GET_JWT = `${process.env.REACT_APP_BASE_URL}/login/`;
 
 export const GET_SOCIAL_BOOKS = `${process.env.REACT_APP_BASE_URL}/social/`;
+
+export const GET_INCOME_CATEGORY = `${process.env.REACT_APP_BASE_URL}/api/category/income`;
+
+export const GET_EXPENDITURE_CATEGORY = `${process.env.REACT_APP_BASE_URL}/api/category/expenditure`;

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -2,8 +2,6 @@ import 'dotenv/config';
 
 export const GET_JWT = `${process.env.REACT_APP_BASE_URL}/login/`;
 
-export const GET_SOCIAL_BOOKS = `${process.env.REACT_APP_BASE_URL}/social/`;
-
 export const GET_INCOME_CATEGORY = `${process.env.REACT_APP_BASE_URL}/api/category/income`;
 
 export const GET_EXPENDITURE_CATEGORY = `${process.env.REACT_APP_BASE_URL}/api/category/expenditure`;

--- a/client/src/utils/axios.ts
+++ b/client/src/utils/axios.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+
+const getToken = () => {
+  return localStorage.getItem('jwt');
+};
+
+const getConfig = () => {
+  const token = getToken();
+  const config = {
+    headers: { token },
+  };
+  return config;
+};
+
+export const getAxios = async (api: string) => {
+  const config = getConfig();
+  const result = await axios.get(api, config);
+  return result;
+};
+
+export const postAxios = async (api: string, data: any) => {
+  const config = getConfig();
+  const result = await axios.post(api, data, config);
+  return result;
+};

--- a/client/src/utils/axios.ts
+++ b/client/src/utils/axios.ts
@@ -1,4 +1,5 @@
-import axios from 'axios';
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import axios, { AxiosResponse } from 'axios';
 
 const getToken = () => {
   return localStorage.getItem('jwt');
@@ -12,14 +13,26 @@ const getConfig = () => {
   return config;
 };
 
-export const getAxios = async (api: string) => {
+export const getAxios = async (api: string): Promise<AxiosResponse<any>> => {
   const config = getConfig();
   const result = await axios.get(api, config);
   return result;
 };
 
-export const postAxios = async (api: string, data: any) => {
+export const postAxios = async (api: string, data: any): Promise<AxiosResponse<any>> => {
   const config = getConfig();
   const result = await axios.post(api, data, config);
+  return result;
+};
+
+export const putAxios = async (api: string, data: any): Promise<AxiosResponse<any>> => {
+  const config = getConfig();
+  const result = await axios.put(api, data, config);
+  return result;
+};
+
+export const deleteAxios = async (api: string): Promise<AxiosResponse<any>> => {
+  const config = getConfig();
+  const result = await axios.delete(api, config);
   return result;
 };

--- a/client/src/views/LoginPage.tsx
+++ b/client/src/views/LoginPage.tsx
@@ -30,7 +30,7 @@ const LoginPage: React.FC<props> = ({ location }: props) => {
       (async () => {
         const jwtToken = await getJWT();
         localStorage.setItem('jwt', jwtToken);
-        document.location.href = '/main';
+        document.location.href = '/';
       })();
     }
   }, []);

--- a/client/src/views/LoginPage.tsx
+++ b/client/src/views/LoginPage.tsx
@@ -4,6 +4,8 @@ import LogoWithSlogan from '@organisms/LogoWithSlogan';
 import CenterContent from '@molecules/CenterContent';
 import BeeBackground from '@organisms/BeeBackground';
 import EasyLogin from '@organisms/EasyLogin';
+import { login } from '@actions/user/type';
+import { useDispatch } from 'react-redux';
 import qs from 'qs';
 import axios from 'axios';
 import * as API from '@utils/api';
@@ -13,6 +15,8 @@ interface props {
 }
 
 const LoginPage: React.FC<props> = ({ location }: props) => {
+  const dispatch = useDispatch();
+
   const slogan = '지갑 속 꿀 같은 돈을 지키는 첫번째 방법';
   useEffect(() => {
     const { code, site, state }: any = qs.parse(location.search, {
@@ -30,6 +34,7 @@ const LoginPage: React.FC<props> = ({ location }: props) => {
       (async () => {
         const jwtToken = await getJWT();
         localStorage.setItem('jwt', jwtToken);
+        dispatch(login());
         document.location.href = '/';
       })();
     }

--- a/client/src/views/MainPage.tsx
+++ b/client/src/views/MainPage.tsx
@@ -92,7 +92,7 @@ const MainPage: React.FC = () => {
             <ColumFlexContainer width="100%" height="100%" alignItems="center">
               <RowFlexContainer width="90%" alignItems="center" justifyContent="space-between">
                 <LeftNormalText>안녕하세요 제구님!</LeftNormalText>
-                <CreateButton link="/social-accountbook/new" />
+                <CreateButton link="/accountbook/social/new" />
               </RowFlexContainer>
               <RowFlexContainer width="90%">
                 <LeftLargeText>

--- a/client/src/views/NotFoundPage.tsx
+++ b/client/src/views/NotFoundPage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from 'styled-components';
+import ColumFlexContainer from '@atoms/div/ColumnFlexContainer';
+import CenterContent from '@molecules/CenterContent';
+import BeeBackground from '@organisms/BeeBackground';
+import TopNavBar from '@organisms/TopNavBar';
+
+const Text = styled.div`
+  text-align: center;
+  margin-top: -20%;
+  font-weight: bold;
+  font-size: 36px;
+`;
+
+const LoginPage: React.FC = () => {
+  return (
+    <>
+      <BeeBackground />
+      <CenterContent>
+        <TopNavBar />
+        <ColumFlexContainer height="100%" justifyContent="center">
+          <Text>404 NOT FOUND</Text>
+        </ColumFlexContainer>
+      </CenterContent>
+    </>
+  );
+};
+
+export default LoginPage;


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- axios utils 구현
    - 앞으로 axios 요청시 해당 utils을 사용해주시면 코드가 훨씬 깔끔할 것 같습니다.
    - put, delete는 아직 없어서 제작하여 사용해야 합니다.
- accountbook store의 틀을 구축하였습니다. 상세 코드나 로직은 추후 구현해야 합니다.
- accountbook store의 틀을 구축하였습니다. 상세 코드나 로직은 추후 구현해야 합니다. (초기화 포함)
- 404 페이지를 구현하여 존재하지 않는 라우터에 접근시 띄워주도록 하였습니다.
- (현재는 단순히 localStorage 값을 기반으로) 로그인 여부를 판단하여 라우터를 반환해주도록 구현하였습니다.

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 리펙토링

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 남아있는 작업
1. 로그인 여부 판별하는 부분 개선
    1차 토큰으로 검사(구현)
    2차 API 요청을 보내서 유효한 토큰인지 검사(미구현) -> 유효하지 않으면 상태 변경
2. 처음 App에 들어올때 (로그인이 되어있다면) store들이 초기화 되어있는지 확인하고 초기화 해주기
    2-1. (다른 유저의 초기값이 남아있을 수 있으므로) 로그인시 초기화
    2-2. 로그인은 되어있으나 초기값이 비어있어도 초기화
    초기화: private, social, category, payment

<br/><br/>