### PR TITLE
Full-feat-init-store store값 초기화 및 토큰 검증

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,26 +15,21 @@ import { RootState } from '@reducers/rootReducer';
 import { setCategory } from '@actions/category/type';
 import { setPayment } from '@actions/payment/type';
 import { setPrivate } from '@actions/accountbook/type';
-import { getAxios } from '@utils/axios';
+import { getAxiosData } from '@utils/axios';
 import * as API from '@utils/api';
-
-const getInitData = async (api: string) => {
-  const { data } = await getAxios(api);
-  return data;
-};
 
 const App: React.FC = () => {
   const dispatch = useDispatch();
   const login = useSelector((state: RootState) => state.user.isLogin);
 
   const initCategory = async () => {
-    const income = await getInitData(API.GET_INCOME_CATEGORY);
-    const expenditure = await getInitData(API.GET_EXPENDITURE_CATEGORY);
+    const income = await getAxiosData(API.GET_INCOME_CATEGORY);
+    const expenditure = await getAxiosData(API.GET_EXPENDITURE_CATEGORY);
     dispatch(setCategory(income.data, expenditure.data));
   };
 
   const initPayment = async () => {
-    const payment = await getInitData(API.GET_PAYMENT);
+    const payment = await getAxiosData(API.GET_PAYMENT);
     dispatch(setPayment(payment.data));
   };
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,16 +13,12 @@ import { CookiesProvider } from 'react-cookie';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
 import { setCategory } from '@actions/category/type';
+import { setPayment } from '@actions/payment/type';
 import { getAxios } from '@utils/axios';
 import * as API from '@utils/api';
 
-const getIncomeCategory = async () => {
-  const { data } = await getAxios(API.GET_INCOME_CATEGORY);
-  return data;
-};
-
-const getExpenditureCategory = async () => {
-  const { data } = await getAxios(API.GET_EXPENDITURE_CATEGORY);
+const getInitData = async (api: string) => {
+  const { data } = await getAxios(api);
   return data;
 };
 
@@ -31,14 +27,20 @@ const App: React.FC = () => {
   const login = useSelector((state: RootState) => state.user.isLogin);
 
   const initCategory = async () => {
-    const income = await getIncomeCategory();
-    const expenditure = await getExpenditureCategory();
+    const income = await getInitData(API.GET_INCOME_CATEGORY);
+    const expenditure = await getInitData(API.GET_EXPENDITURE_CATEGORY);
     dispatch(setCategory(income.data, expenditure.data));
+  };
+
+  const initPayment = async () => {
+    const payment = await getInitData(API.GET_PAYMENT);
+    dispatch(setPayment(payment.data));
   };
 
   useEffect(() => {
     if (login) {
       initCategory();
+      initPayment();
     }
   }, [login]);
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
 import { setCategory } from '@actions/category/type';
 import { setPayment } from '@actions/payment/type';
+import { setPrivate } from '@actions/accountbook/type';
 import { getAxios } from '@utils/axios';
 import * as API from '@utils/api';
 
@@ -37,10 +38,15 @@ const App: React.FC = () => {
     dispatch(setPayment(payment.data));
   };
 
+  const initAccountBook = () => {
+    dispatch(setPrivate());
+  };
+
   useEffect(() => {
     if (login) {
       initCategory();
       initPayment();
+      initAccountBook();
     }
   }, [login]);
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import LoginPage from '@views/LoginPage';
 import MainPage from '@views/MainPage';
 import NotificationPage from '@views/NotificationPage';
@@ -10,11 +10,37 @@ import NotFoundPage from '@views/NotFoundPage';
 import GlobalStyle from '@shared/global';
 import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import { CookiesProvider } from 'react-cookie';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
+import { setCategory } from '@actions/category/type';
+import { getAxios } from '@utils/axios';
+import * as API from '@utils/api';
+
+const getIncomeCategory = async () => {
+  const { data } = await getAxios(API.GET_INCOME_CATEGORY);
+  return data;
+};
+
+const getExpenditureCategory = async () => {
+  const { data } = await getAxios(API.GET_EXPENDITURE_CATEGORY);
+  return data;
+};
 
 const App: React.FC = () => {
+  const dispatch = useDispatch();
   const login = useSelector((state: RootState) => state.user.isLogin);
+
+  const initCategory = async () => {
+    const income = await getIncomeCategory();
+    const expenditure = await getExpenditureCategory();
+    dispatch(setCategory(income.data, expenditure.data));
+  };
+
+  useEffect(() => {
+    if (login) {
+      initCategory();
+    }
+  }, [login]);
 
   const loginRouter = (
     <>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,11 +16,22 @@ import { setCategory } from '@actions/category/type';
 import { setPayment } from '@actions/payment/type';
 import { setPrivate } from '@actions/accountbook/type';
 import { getAxiosData } from '@utils/axios';
+import { logout, setName } from '@actions/user/type';
 import * as API from '@utils/api';
 
 const App: React.FC = () => {
   const dispatch = useDispatch();
   const login = useSelector((state: RootState) => state.user.isLogin);
+
+  const checkValidToken = async () => {
+    try {
+      const name = await getAxiosData(API.GET_USER_NAME);
+      dispatch(setName(name.data));
+    } catch {
+      localStorage.removeItem('jwt');
+      dispatch(logout());
+    }
+  };
 
   const initCategory = async () => {
     const income = await getAxiosData(API.GET_INCOME_CATEGORY);
@@ -39,6 +50,7 @@ const App: React.FC = () => {
 
   useEffect(() => {
     if (login) {
+      checkValidToken();
       initCategory();
       initPayment();
       initAccountBook();

--- a/client/src/actions/accountbook/type.ts
+++ b/client/src/actions/accountbook/type.ts
@@ -1,16 +1,7 @@
 import { ActionProps } from '@interfaces/action';
 
-export const INIT_DATA = 'accountbook/INIT_DATA' as const;
 export const SET_PRIVATE = 'accountbook/SET_PRIVATE' as const;
 export const SET_SOCIAL = 'accountbook/SET_SOCIAL' as const;
-
-export const initData = (social: number[], privateId: number): ActionProps => ({
-  type: INIT_DATA,
-  payload: {
-    social,
-    private: privateId,
-  },
-});
 
 export const setPrivate = (): ActionProps => ({
   type: SET_PRIVATE,

--- a/client/src/actions/category/type.ts
+++ b/client/src/actions/category/type.ts
@@ -1,6 +1,17 @@
 import { ActionProps } from '@interfaces/action';
+import { Category } from '@interfaces/category';
+
+export const SET_CATEGORY = 'category/SET_CATEGORY' as const;
 
 export const GET_CATEGORY = 'category/GET_CATEGORY' as const;
+
+export const setCategory = (income: Category[], expenditure: Category[]): ActionProps => ({
+  type: SET_CATEGORY,
+  payload: {
+    income,
+    expenditure,
+  },
+});
 
 export const getCategory = (): ActionProps => ({
   type: GET_CATEGORY,

--- a/client/src/actions/category/type.ts
+++ b/client/src/actions/category/type.ts
@@ -3,16 +3,10 @@ import { Category } from '@interfaces/category';
 
 export const SET_CATEGORY = 'category/SET_CATEGORY' as const;
 
-export const GET_CATEGORY = 'category/GET_CATEGORY' as const;
-
 export const setCategory = (income: Category[], expenditure: Category[]): ActionProps => ({
   type: SET_CATEGORY,
   payload: {
     income,
     expenditure,
   },
-});
-
-export const getCategory = (): ActionProps => ({
-  type: GET_CATEGORY,
 });

--- a/client/src/actions/payment/type.ts
+++ b/client/src/actions/payment/type.ts
@@ -1,0 +1,9 @@
+import { ActionProps } from '@interfaces/action';
+import { Payment } from '@interfaces/payment';
+
+export const SET_PAYMENT = 'payment/SET_PAYMENT' as const;
+
+export const setPayment = (payment: Payment[]): ActionProps => ({
+  type: SET_PAYMENT,
+  payload: payment,
+});

--- a/client/src/actions/user/type.ts
+++ b/client/src/actions/user/type.ts
@@ -1,7 +1,8 @@
 import { ActionProps } from '@interfaces/action';
 
-export const LOGIN = 'user/login' as const;
-export const LOGOUT = 'user/logout' as const;
+export const LOGIN = 'user/LOGIN' as const;
+export const LOGOUT = 'user/LOGOUT' as const;
+export const SET_NAME = 'user/SET_NAME' as const;
 
 export const login = (): ActionProps => ({
   type: LOGIN,
@@ -9,4 +10,9 @@ export const login = (): ActionProps => ({
 
 export const logout = (): ActionProps => ({
   type: LOGOUT,
+});
+
+export const setName = (name: string): ActionProps => ({
+  type: SET_NAME,
+  payload: name,
 });

--- a/client/src/components/molecules/UserImages/UserImages.tsx
+++ b/client/src/components/molecules/UserImages/UserImages.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import UserImage from '@atoms/img/UserImage';
 import NoOne from '@img/no-one.png';
+import getRandomKey from '@utils/random.ts';
 
 interface Props {
   links: string[];
@@ -25,7 +26,7 @@ const userImages: React.FC<Props> = ({ links }: Props) => {
   }
   const allImage = userLink.map((user) => (
     <Images>
-      <UserImage link={user} />
+      <UserImage link={user} key={getRandomKey()} />
     </Images>
   ));
   return <UserImages>{allImage}</UserImages>;

--- a/client/src/components/organisms/MyAccountInfoCard/MyAccountInfoCard.tsx
+++ b/client/src/components/organisms/MyAccountInfoCard/MyAccountInfoCard.tsx
@@ -8,6 +8,9 @@ import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import LeftNormalText from '@atoms/p/LeftNormalText';
 import SquircleShortButton from '@atoms/button/SquircleShortButton';
 import CircleGraph from '@atoms/graph/CircleGraph';
+import { useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { setPrivate } from '@actions/accountbook/type';
 
 interface Props {
   categoryList: Array<string>;
@@ -38,13 +41,21 @@ const MyAccountInfoCard: React.FC<Props> = ({
   expend,
   link,
 }: Props) => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+
+  const toMyAccountBook = () => {
+    dispatch(setPrivate());
+    history.push('/accountbook');
+  };
+
   return (
     <SquircleCard {...squircleCardArgs}>
       <ColumnFlexContainer width="100%" height="100%">
         <RowFlexContainer justifyContent="space-between" width="100%" height="30%">
           <UserImage size="36px" link={link} />
           <LeftNormalText color="white">내 가계부</LeftNormalText>
-          <SquircleShortButton>조회하기</SquircleShortButton>
+          <SquircleShortButton onClick={toMyAccountBook}>조회하기</SquircleShortButton>
         </RowFlexContainer>
         <RowFlexContainer justifyContent="space-between" width="100%" height="70%">
           <ColumnFlexContainer width="70%" height="100%">

--- a/client/src/components/organisms/SocialAccountBook/SocialAccountBook.stories.tsx
+++ b/client/src/components/organisms/SocialAccountBook/SocialAccountBook.stories.tsx
@@ -9,16 +9,17 @@ export default {
 export const socialAccountBook = (): JSX.Element => {
   return (
     <SocialAccountBook
-      links={[
+      images={[
         'https://avatars2.githubusercontent.com/u/46099115?s=460&u=1e04610d430875d8189d2b212b8c2d9fc268b9db&v=4',
         'https://avatars3.githubusercontent.com/u/55074799?s=460&u=2f70319c2f55ba5e26db060ba21d66a9cab35732&v=4',
         'https://avatars2.githubusercontent.com/u/50297117?s=460&u=2ddc78ef0045b75f6fb405f1763304a7481d46e4&v=4',
       ]}
-      title="부캠가계부"
+      name="부캠가계부"
       description="부스트캠프 가계부 입니다"
-      fontSize="15px"
-      inMoney={102349}
-      exMoney={9932}
+      incomeSum="102349"
+      expenditureSum="9932"
+      color="#153721"
+      id={1}
     />
   );
 };

--- a/client/src/components/organisms/SocialAccountBook/SocialAccountBook.tsx
+++ b/client/src/components/organisms/SocialAccountBook/SocialAccountBook.tsx
@@ -4,16 +4,7 @@ import SquircleCard from '@atoms/div/SquircleCard';
 import UserImages from '@molecules/UserImages';
 import CardInfo from '@molecules/CardInfo';
 import CardNumberText from '@molecules/CardNumberText';
-
-interface Props {
-  links: string[];
-  title: string;
-  description: string;
-  fontSize: string;
-  inMoney: number;
-  exMoney: number;
-  backgroundColor?: string;
-}
+import { SocialBook } from '@interfaces/accountbook';
 
 const LeftBox = styled.div`
   display: flex;
@@ -34,25 +25,28 @@ const RightBox = styled.div`
   align-items: center;
 `;
 
-const socialAccountBook: React.FC<Props> = ({
-  links,
-  title,
+const socialAccountBook: React.FC<SocialBook> = ({
+  name,
   description,
-  fontSize,
-  inMoney,
-  exMoney,
-  backgroundColor,
-}: Props) => {
+  color,
+  incomeSum,
+  expenditureSum,
+  images,
+}: SocialBook) => {
   return (
-    <SquircleCard backgroundColor={backgroundColor}>
+    <SquircleCard backgroundColor={color}>
       <LeftBox>
-        <UserImages links={links} />
+        <UserImages links={images} />
       </LeftBox>
       <CenterBox>
-        <CardInfo title={title} description={description} />
+        <CardInfo title={name} description={description} />
       </CenterBox>
       <RightBox>
-        <CardNumberText fontSize={fontSize} inMoney={inMoney} exMoney={exMoney} />
+        <CardNumberText
+          fontSize="1rem"
+          inMoney={Number(incomeSum)}
+          exMoney={Number(expenditureSum)}
+        />
       </RightBox>
     </SquircleCard>
   );

--- a/client/src/components/organisms/SocialAccountBook/SocialAccountBook.tsx
+++ b/client/src/components/organisms/SocialAccountBook/SocialAccountBook.tsx
@@ -4,7 +4,17 @@ import SquircleCard from '@atoms/div/SquircleCard';
 import UserImages from '@molecules/UserImages';
 import CardInfo from '@molecules/CardInfo';
 import CardNumberText from '@molecules/CardNumberText';
+import { useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { setSocial } from '@actions/accountbook/type';
 import { SocialBook } from '@interfaces/accountbook';
+
+const Container = styled.button`
+  background-color: transparent;
+  border: 0px;
+  width: 100%;
+  cursor: pointer;
+`;
 
 const LeftBox = styled.div`
   display: flex;
@@ -26,6 +36,7 @@ const RightBox = styled.div`
 `;
 
 const socialAccountBook: React.FC<SocialBook> = ({
+  id,
   name,
   description,
   color,
@@ -33,22 +44,32 @@ const socialAccountBook: React.FC<SocialBook> = ({
   expenditureSum,
   images,
 }: SocialBook) => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+
+  const toSocialAccountBook = () => {
+    dispatch(setSocial(id));
+    history.push('/accountbook');
+  };
+
   return (
-    <SquircleCard backgroundColor={color}>
-      <LeftBox>
-        <UserImages links={images} />
-      </LeftBox>
-      <CenterBox>
-        <CardInfo title={name} description={description} />
-      </CenterBox>
-      <RightBox>
-        <CardNumberText
-          fontSize="1rem"
-          inMoney={Number(incomeSum)}
-          exMoney={Number(expenditureSum)}
-        />
-      </RightBox>
-    </SquircleCard>
+    <Container onClick={toSocialAccountBook}>
+      <SquircleCard backgroundColor={color}>
+        <LeftBox>
+          <UserImages links={images} />
+        </LeftBox>
+        <CenterBox>
+          <CardInfo title={name} description={description} />
+        </CenterBox>
+        <RightBox>
+          <CardNumberText
+            fontSize="1rem"
+            inMoney={Number(incomeSum)}
+            exMoney={Number(expenditureSum)}
+          />
+        </RightBox>
+      </SquircleCard>
+    </Container>
   );
 };
 

--- a/client/src/interfaces/accountbook.ts
+++ b/client/src/interfaces/accountbook.ts
@@ -1,0 +1,9 @@
+export interface SocialBook {
+  id: number;
+  name: string;
+  description: string;
+  color: string;
+  incomeSum: string | null;
+  expenditureSum: string | null;
+  images: string[];
+}

--- a/client/src/interfaces/payment.ts
+++ b/client/src/interfaces/payment.ts
@@ -1,0 +1,4 @@
+export interface Payment {
+  id: number;
+  name: string;
+}

--- a/client/src/reducers/accountbook.ts
+++ b/client/src/reducers/accountbook.ts
@@ -1,29 +1,15 @@
-import {
-  INIT_DATA,
-  SET_PRIVATE,
-  SET_SOCIAL,
-  initData,
-  setPrivate,
-  setSocial,
-} from '@actions/accountbook/type';
+import { SET_PRIVATE, SET_SOCIAL, setPrivate, setSocial } from '@actions/accountbook/type';
 
-type AccountBookAction =
-  | ReturnType<typeof initData>
-  | ReturnType<typeof setPrivate>
-  | ReturnType<typeof setSocial>;
+type AccountBookAction = ReturnType<typeof setPrivate> | ReturnType<typeof setSocial>;
 
 type AccountBookState = {
   type: string;
-  social: number[];
-  private: number;
-  now: number;
+  socialId: number;
 };
 
 const initialState: AccountBookState = {
   type: 'PRIVATE',
-  social: [],
-  private: 0,
-  now: 0,
+  socialId: 0,
 };
 
 const accountBook = (
@@ -31,17 +17,10 @@ const accountBook = (
   action: AccountBookAction,
 ): AccountBookState => {
   switch (action.type) {
-    case INIT_DATA:
-      return {
-        type: 'PRIVATE',
-        social: action.payload.social,
-        private: action.payload.private,
-        now: 0,
-      };
     case SET_PRIVATE:
-      return { type: 'PRIVATE', social: state.social, private: state.private, now: 0 };
+      return { type: 'PRIVATE', socialId: 0 };
     case SET_SOCIAL:
-      return { type: 'SOCIAL', social: state.social, private: state.private, now: action.payload };
+      return { type: 'SOCIAL', socialId: action.payload };
     default:
       return state;
   }

--- a/client/src/reducers/category.ts
+++ b/client/src/reducers/category.ts
@@ -1,7 +1,7 @@
-import { SET_CATEGORY, GET_CATEGORY, setCategory, getCategory } from '@actions/category/type';
+import { SET_CATEGORY, setCategory } from '@actions/category/type';
 import { Category } from '@interfaces/category';
 
-type CategoryAction = ReturnType<typeof setCategory> | ReturnType<typeof getCategory>;
+type CategoryAction = ReturnType<typeof setCategory>;
 
 type CategoryState = {
   income: Category[];
@@ -17,8 +17,6 @@ const category = (state: CategoryState = initialState, action: CategoryAction): 
   switch (action.type) {
     case SET_CATEGORY:
       return { income: action.payload.income, expenditure: action.payload.expenditure };
-    case GET_CATEGORY:
-      return { income: state.income, expenditure: state.expenditure };
     default:
       return state;
   }

--- a/client/src/reducers/category.ts
+++ b/client/src/reducers/category.ts
@@ -1,32 +1,12 @@
-import { GET_CATEGORY, getCategory } from '@actions/category/type';
+import { SET_CATEGORY, GET_CATEGORY, setCategory, getCategory } from '@actions/category/type';
 import { Category } from '@interfaces/category';
-import { getAxios } from '@utils/axios';
-import * as API from '@utils/api';
 
-type CategoryAction = ReturnType<typeof getCategory>;
+type CategoryAction = ReturnType<typeof setCategory> | ReturnType<typeof getCategory>;
 
 type CategoryState = {
   income: Category[];
   expenditure: Category[];
 };
-
-const getIncomeCategory = async () => {
-  const { data } = await getAxios(API.GET_INCOME_CATEGORY);
-  return data;
-};
-
-const getExpenditureCategory = async () => {
-  const { data } = await getAxios(API.GET_EXPENDITURE_CATEGORY);
-  return data;
-};
-
-const initCategory = async () => {
-  const income = await getIncomeCategory();
-  const expenditure = await getExpenditureCategory();
-  return { income, expenditure };
-};
-
-initCategory();
 
 const initialState = {
   income: [],
@@ -35,6 +15,8 @@ const initialState = {
 
 const category = (state: CategoryState = initialState, action: CategoryAction): CategoryState => {
   switch (action.type) {
+    case SET_CATEGORY:
+      return { income: action.payload.income, expenditure: action.payload.expenditure };
     case GET_CATEGORY:
       return { income: state.income, expenditure: state.expenditure };
     default:

--- a/client/src/reducers/payment.ts
+++ b/client/src/reducers/payment.ts
@@ -1,0 +1,23 @@
+import { SET_PAYMENT, setPayment } from '@actions/payment/type';
+import { Payment } from '@interfaces/payment';
+
+type PaymentAction = ReturnType<typeof setPayment>;
+
+type PaymentState = {
+  payment: Payment[];
+};
+
+const initialState = {
+  payment: [],
+};
+
+const category = (state: PaymentState = initialState, action: PaymentAction): PaymentState => {
+  switch (action.type) {
+    case SET_PAYMENT:
+      return { payment: action.payload };
+    default:
+      return state;
+  }
+};
+
+export default category;

--- a/client/src/reducers/user.ts
+++ b/client/src/reducers/user.ts
@@ -23,7 +23,7 @@ const user = (state: UserState = initialState, action: UserAction): UserState =>
     case LOGOUT:
       return { isLogin: false, name: '' };
     case SET_NAME:
-      return { isLogin: false, name: action.payload };
+      return { isLogin: state.isLogin, name: action.payload };
     default:
       return state;
   }

--- a/client/src/reducers/user.ts
+++ b/client/src/reducers/user.ts
@@ -1,9 +1,10 @@
-import { LOGIN, LOGOUT, login, logout } from '@actions/user/type';
+import { LOGIN, LOGOUT, SET_NAME, login, logout, setName } from '@actions/user/type';
 
-type UserAction = ReturnType<typeof login> | ReturnType<typeof logout>;
+type UserAction = ReturnType<typeof login> | ReturnType<typeof logout> | ReturnType<typeof setName>;
 
 type UserState = {
   isLogin: boolean;
+  name: string;
 };
 
 const initIsLogin = () => {
@@ -12,14 +13,17 @@ const initIsLogin = () => {
 
 const initialState: UserState = {
   isLogin: initIsLogin(),
+  name: '',
 };
 
 const user = (state: UserState = initialState, action: UserAction): UserState => {
   switch (action.type) {
     case LOGIN:
-      return { isLogin: true };
+      return { isLogin: true, name: state.name };
     case LOGOUT:
-      return { isLogin: false };
+      return { isLogin: false, name: '' };
+    case SET_NAME:
+      return { isLogin: false, name: action.payload };
     default:
       return state;
   }

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -2,6 +2,8 @@ import 'dotenv/config';
 
 export const GET_JWT = `${process.env.REACT_APP_BASE_URL}/login/`;
 
+export const GET_USER_NAME = `${process.env.REACT_APP_BASE_URL}/api/user/name`;
+
 export const GET_SOCIAL_BOOKS = `${process.env.REACT_APP_BASE_URL}/api/social/list`;
 
 export const GET_MASTER_BOOKS = `${process.env.REACT_APP_BASE_URL}/api/social/list/master`;

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -2,6 +2,10 @@ import 'dotenv/config';
 
 export const GET_JWT = `${process.env.REACT_APP_BASE_URL}/login/`;
 
+export const GET_SOCIAL_BOOKS = `${process.env.REACT_APP_BASE_URL}/api/social/list`;
+
+export const GET_MASTER_BOOKS = `${process.env.REACT_APP_BASE_URL}/api/social/list/master`;
+
 export const GET_INCOME_CATEGORY = `${process.env.REACT_APP_BASE_URL}/api/category/income`;
 
 export const GET_EXPENDITURE_CATEGORY = `${process.env.REACT_APP_BASE_URL}/api/category/expenditure`;

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -5,3 +5,5 @@ export const GET_JWT = `${process.env.REACT_APP_BASE_URL}/login/`;
 export const GET_INCOME_CATEGORY = `${process.env.REACT_APP_BASE_URL}/api/category/income`;
 
 export const GET_EXPENDITURE_CATEGORY = `${process.env.REACT_APP_BASE_URL}/api/category/expenditure`;
+
+export const GET_PAYMENT = `${process.env.REACT_APP_BASE_URL}/api/payment`;

--- a/client/src/utils/axios.ts
+++ b/client/src/utils/axios.ts
@@ -19,6 +19,11 @@ export const getAxios = async (api: string): Promise<AxiosResponse<any>> => {
   return result;
 };
 
+export const getAxiosData = async (api: string) => {
+  const { data } = await getAxios(api);
+  return data;
+};
+
 export const postAxios = async (api: string, data: any): Promise<AxiosResponse<any>> => {
   const config = getConfig();
   const result = await axios.post(api, data, config);

--- a/client/src/utils/random.ts
+++ b/client/src/utils/random.ts
@@ -1,0 +1,5 @@
+const getRandomKey = (): string => {
+  return Math.random().toString(36).substr(2, 11);
+};
+
+export default getRandomKey;

--- a/client/src/views/MainPage.tsx
+++ b/client/src/views/MainPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import TopNavBar from '@organisms/TopNavBar';
 import ColumFlexContainer from '@atoms/div/ColumnFlexContainer';
 import CenterContent from '@molecules/CenterContent';
@@ -10,15 +10,48 @@ import CreateButton from '@atoms/button/CreateButton';
 import LeftNormalText from '@atoms/p/LeftNormalText';
 import LeftLargeText from '@atoms/p/LeftLargeText';
 import SocialAccountBook from '@organisms/SocialAccountBook';
+import { SocialBook } from '@interfaces/accountbook';
+import { getAxiosData } from '@utils/axios';
+import * as API from '@utils/api';
+
+interface chipsProps {
+  categoryList: Array<string>;
+  amountList: Array<number>;
+  income: number;
+  expend: number;
+  link: string;
+}
+
+const MarginBox = styled.div`
+  width: 100%;
+  height: 2rem;
+`;
+
+const PositionBox = styled.div`
+  margin-top: 3rem;
+  width: 90%;
+`;
+
+const CardBox = styled.div`
+  width: 100%;
+  margin-top: 6rem;
+`;
+
+// {
+//   links: [
+//     'https://avatars3.githubusercontent.com/u/55074799?s=460&u=2f70319c2f55ba5e26db060ba21d66a9cab35732&v=4',
+//   ],
+//   title: '커플통장',
+//   description: '데이트 통장 가계부입니다',
+//   fontSize: '15px',
+//   inMoney: 1234,
+//   exMoney: 619012,
+//   backgroundColor: '#F2A8AF',
+// }
 
 const MainPage: React.FC = () => {
-  interface chipsProps {
-    categoryList: Array<string>;
-    amountList: Array<number>;
-    income: number;
-    expend: number;
-    link: string;
-  }
+  const [masterBooks, setMasterBooks] = useState<SocialBook[]>([]);
+  const [socialBooks, setSocialBooks] = useState<SocialBook[]>([]);
 
   const chipsArgs: chipsProps = {
     categoryList: ['여가', '외식', '쇼핑', '교통'],
@@ -29,58 +62,20 @@ const MainPage: React.FC = () => {
       'https://avatars2.githubusercontent.com/u/46099115?s=460&u=1e04610d430875d8189d2b212b8c2d9fc268b9db&v=4',
   };
 
-  const SocialArgs = [
-    {
-      links: [
-        'https://avatars2.githubusercontent.com/u/46099115?s=460&u=1e04610d430875d8189d2b212b8c2d9fc268b9db&v=4',
-        'https://avatars3.githubusercontent.com/u/55074799?s=460&u=2f70319c2f55ba5e26db060ba21d66a9cab35732&v=4',
-        'https://avatars2.githubusercontent.com/u/50297117?s=460&u=2ddc78ef0045b75f6fb405f1763304a7481d46e4&v=4',
-      ],
-      title: '부캠가계부',
-      description: '부스트캠프 가계부 입니다',
-      fontSize: '15px',
-      inMoney: 102349,
-      exMoney: 9932,
-    },
-    {
-      links: [
-        'https://avatars2.githubusercontent.com/u/46099115?s=460&u=1e04610d430875d8189d2b212b8c2d9fc268b9db&v=4',
-        'https://avatars3.githubusercontent.com/u/55074799?s=460&u=2f70319c2f55ba5e26db060ba21d66a9cab35732&v=4',
-      ],
-      title: '회식가계부',
-      description: 'Honey In Money 회식비',
-      fontSize: '15px',
-      inMoney: 314234,
-      exMoney: 838866,
-      backgroundColor: '#A0D3DB',
-    },
-    {
-      links: [
-        'https://avatars3.githubusercontent.com/u/55074799?s=460&u=2f70319c2f55ba5e26db060ba21d66a9cab35732&v=4',
-      ],
-      title: '커플통장',
-      description: '데이트 통장 가계부입니다',
-      fontSize: '15px',
-      inMoney: 1234,
-      exMoney: 619012,
-      backgroundColor: '#F2A8AF',
-    },
-  ];
+  const initMasterBooks = async () => {
+    const master = await getAxiosData(API.GET_MASTER_BOOKS);
+    setMasterBooks(master.data);
+  };
 
-  const MarginBox = styled.div`
-    width: 100%;
-    height: 2rem;
-  `;
+  const initSocialBooks = async () => {
+    const social = await getAxiosData(API.GET_SOCIAL_BOOKS);
+    setSocialBooks(social.data);
+  };
 
-  const PositionBox = styled.div`
-    margin-top: 3rem;
-    width: 90%;
-  `;
-
-  const CardBox = styled.div`
-    width: 100%;
-    margin-top: 6rem;
-  `;
+  useEffect(() => {
+    initMasterBooks();
+    initSocialBooks();
+  }, []);
 
   return (
     <>
@@ -106,8 +101,13 @@ const MainPage: React.FC = () => {
           </AccountBookBackground>
           <ColumFlexContainer width="90%">
             <CardBox>
-              {SocialArgs.map((ele) => {
-                return <SocialAccountBook {...ele} />;
+              {masterBooks.map((book) => {
+                return <SocialAccountBook key={book.id} {...book} />;
+              })}
+            </CardBox>
+            <CardBox>
+              {socialBooks.map((book) => {
+                return <SocialAccountBook key={book.id} {...book} />;
               })}
             </CardBox>
           </ColumFlexContainer>

--- a/client/src/views/MainPage.tsx
+++ b/client/src/views/MainPage.tsx
@@ -9,6 +9,7 @@ import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import CreateButton from '@atoms/button/CreateButton';
 import LeftNormalText from '@atoms/p/LeftNormalText';
 import LeftLargeText from '@atoms/p/LeftLargeText';
+import Bold from '@atoms/span/BoldSpan';
 import SocialAccountBook from '@organisms/SocialAccountBook';
 import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
@@ -77,7 +78,9 @@ const MainPage: React.FC = () => {
           <AccountBookBackground height="250px">
             <ColumFlexContainer width="100%" height="100%" alignItems="center">
               <RowFlexContainer width="90%" alignItems="center" justifyContent="space-between">
-                <LeftNormalText>안녕하세요 {user}님!</LeftNormalText>
+                <LeftNormalText>
+                  안녕하세요 <Bold>{user}</Bold>님!
+                </LeftNormalText>
                 <CreateButton link="/accountbook/social/new" />
               </RowFlexContainer>
               <RowFlexContainer width="90%">

--- a/client/src/views/MainPage.tsx
+++ b/client/src/views/MainPage.tsx
@@ -10,6 +10,8 @@ import CreateButton from '@atoms/button/CreateButton';
 import LeftNormalText from '@atoms/p/LeftNormalText';
 import LeftLargeText from '@atoms/p/LeftLargeText';
 import SocialAccountBook from '@organisms/SocialAccountBook';
+import { useSelector } from 'react-redux';
+import { RootState } from '@reducers/rootReducer';
 import { SocialBook } from '@interfaces/accountbook';
 import { getAxiosData } from '@utils/axios';
 import * as API from '@utils/api';
@@ -37,21 +39,10 @@ const CardBox = styled.div`
   margin-top: 6rem;
 `;
 
-// {
-//   links: [
-//     'https://avatars3.githubusercontent.com/u/55074799?s=460&u=2f70319c2f55ba5e26db060ba21d66a9cab35732&v=4',
-//   ],
-//   title: '커플통장',
-//   description: '데이트 통장 가계부입니다',
-//   fontSize: '15px',
-//   inMoney: 1234,
-//   exMoney: 619012,
-//   backgroundColor: '#F2A8AF',
-// }
-
 const MainPage: React.FC = () => {
   const [masterBooks, setMasterBooks] = useState<SocialBook[]>([]);
   const [socialBooks, setSocialBooks] = useState<SocialBook[]>([]);
+  const user = useSelector((state: RootState) => state.user.name);
 
   const chipsArgs: chipsProps = {
     categoryList: ['여가', '외식', '쇼핑', '교통'],
@@ -86,7 +77,7 @@ const MainPage: React.FC = () => {
           <AccountBookBackground height="250px">
             <ColumFlexContainer width="100%" height="100%" alignItems="center">
               <RowFlexContainer width="90%" alignItems="center" justifyContent="space-between">
-                <LeftNormalText>안녕하세요 제구님!</LeftNormalText>
+                <LeftNormalText>안녕하세요 {user}님!</LeftNormalText>
                 <CreateButton link="/accountbook/social/new" />
               </RowFlexContainer>
               <RowFlexContainer width="90%">

--- a/client/src/views/MyPage.tsx
+++ b/client/src/views/MyPage.tsx
@@ -13,7 +13,7 @@ import { RootState } from '@reducers/rootReducer';
 const MyPage: React.FC = () => {
   const modalView = useSelector((state: RootState) => state.modal.view);
   // TODO : 실제 로그인 유저의 정보를 받아오기
-  const name = '임시 이름';
+  const user = useSelector((state: RootState) => state.user.name);
   const profile =
     'https://camo.githubusercontent.com/80afeacc15fc9527cacd6a8257613bcc97967d63947bbb8e2f6efe0a2ed8d59d/68747470733a2f2f692e696d6775722e636f6d2f536c7568554c712e6a7067';
 
@@ -22,7 +22,7 @@ const MyPage: React.FC = () => {
       <BeeBackground />
       <CenterContent>
         <TopNavBar />
-        <MyPageUserMenu name={name} profile={profile} />
+        <MyPageUserMenu name={user} profile={profile} />
         <MyPageMenu />
       </CenterContent>
       {modalView === 'AccountBookAccept' && <AccountBookAcceptModal />}

--- a/server/src/model/query/userQuery.ts
+++ b/server/src/model/query/userQuery.ts
@@ -1,5 +1,6 @@
 const userQuery = {
   READ_USER: 'SELECT * FROM users WHERE pid = ? AND oauth_origin = ?',
+  READ_USER_NAME: 'SELECT name FROM users WHERE id = ?',
   CREATE_USER:
     'INSERT INTO users (pid, email, name, region, picture, color, is_sunday, oauth_origin) VALUES(?,?,?,?,?,?,?,?)',
 };

--- a/server/src/oauth/service.ts
+++ b/server/src/oauth/service.ts
@@ -8,7 +8,7 @@ const axios = require('axios').default;
 
 const createJWTtoken = (data: OauthUserData, site: string) => {
   const jwtToken = jwt.sign(
-    { login: data.name, id: data.id, oAuthOrigin: site, uid: data.uid },
+    { id: data.id, oAuthOrigin: site, uid: data.uid },
     process.env.JWT_SECRET,
     {
       expiresIn: '1d',

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -1,3 +1,4 @@
+import userRouter from './user/router';
 import socialBookRouter from './socialBook/router';
 import privateBookRouter from './privateBook/router';
 import paymentRouter from './payment/router';
@@ -6,6 +7,7 @@ import categoryRouter from './category/router';
 const Router = require('koa-router');
 const router = new Router();
 
+router.use('/user', userRouter.routes());
 router.use('/social', socialBookRouter.routes());
 router.use('/private', privateBookRouter.routes());
 router.use('/payment', paymentRouter.routes());

--- a/server/src/user/controller.ts
+++ b/server/src/user/controller.ts
@@ -1,0 +1,12 @@
+import { Context } from 'koa';
+import * as response from '../utils/response';
+import 'dotenv/config';
+import * as Service from './service';
+
+export const getUserName = async (ctx: Context) => {
+  const userId = ctx.userData.uid;
+  const result = await Service.getUserName(userId);
+  response.success(ctx, result);
+};
+
+export default getUserName;

--- a/server/src/user/router.ts
+++ b/server/src/user/router.ts
@@ -1,0 +1,9 @@
+import * as Controller from './controller';
+
+const Router = require('@koa/router');
+
+const router = new Router();
+
+router.get('/name', Controller.getUserName);
+
+export default router;

--- a/server/src/user/service.ts
+++ b/server/src/user/service.ts
@@ -1,0 +1,10 @@
+import 'dotenv/config';
+import sql from '../model/db';
+import query from '../model/query';
+
+export const getUserName = async (userId: number) => {
+  const [result] = await sql(query.READ_USER_NAME, [userId]);
+  return result.name;
+};
+
+export default getUserName;


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- category, payment, accountbook, user의 store(reducer, action)을 제작하였습니다.
- 페이지 첫 로딩시 토큰의 유효성을 검사하고 유효할 시 사용자 이름을 지정해주었습니다.
    - 유효하지 않은 토큰일 경우 토큰을 삭제하고 logout 시켜 login페이지로 이동시켰습니다.
- 페이지 첫 로딩시 category, (user의) payment, accountbook값을 초기화 시켜주었습니다.
- 소셜 가계부 및 사용자 가계부를 클릭할 시 store 값을 update 시키고 해당 페이지로 이동시켜주었습니다.
- 사용자의 이름을 반환해주는 API를 개발하였습니다.
> http://localhost:3000/api/user/name
```json
// 200 OK
{
    "status": "success",
    "data": "Doyeon Kim"
}
```

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 페이지 개발시 key를 지정해주지 않거나 props를 올바르게 넘겨주지 않은 경우 등이 종종 존재하여 페이지 console 창에 오류 메시지가 많이 뜨고 있는 것 같습니다. 각자 자신이 개발한 부분 중 관련 부분이 있다면 수정부탁드립니다🤗

- 자신이 마스터인 페이지의 경우 setting 버튼이 나타나야하며 해당 페이지로 이동가능해야합니다. 개발 부탁드립니다.
    - 마스터인 가계부와 (일반)소셜 가계부를 따로 불러왔습니다.
- UI 개선이 필요해보입니다.

<br/><br/>
