### PR TITLE
BE-feat-월별 통계 API 구현

### DIFF
--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -11,6 +11,7 @@
   },
   "plugins": ["@typescript-eslint", "prettier"],
   "rules": {
+    "no-restricted-syntax":"off",
     "semi": "error",
     "prettier/prettier": [
       "error",

--- a/server/src/model/query/socialBookQuery.ts
+++ b/server/src/model/query/socialBookQuery.ts
@@ -40,10 +40,12 @@ const socialBookQuery = {
   READ_BELONG_SOCIAL_BOOK_LIST: `SELECT accountbook_id FROM social_accountbook_users WHERE user_id = ? AND state = 2 OR state = 0;`,
   CREATE_SOCIAL_TRANSACTION:
     'INSERT INTO social_transaction (accountbook_id, user_id, category_id, payment_id, date, title, amount) VALUES(?,?,?,?,?,?,?)',
-  READ_MONTHLY_STATISTICS_EXPEND: `SELECT SUM(amount) from social_transaction 
-  where accountbook_id = ? AND date >= ? AND date < ? AND payment_id IS NOT NULL`,
-  READ_MONTHLY_STATISTICS_INCOME: `SELECT SUM(amount) from social_transaction 
-  where accountbook_id = ? AND date >= ? AND date < ? AND payment_id IS NULL`,
+  READ_MONTHLY_STATISTICS_EXPEND: `
+  SELECT SUM(amount) FROM social_transaction 
+  WHERE accountbook_id = ? AND date >= ? AND date < ? AND payment_id IS NOT NULL`,
+  READ_MONTHLY_STATISTICS_INCOME: `
+  SELECT SUM(amount) FROM social_transaction 
+  WHERE accountbook_id = ? AND date >= ? AND date < ? AND payment_id IS NULL`,
 };
 
 export default socialBookQuery;

--- a/server/src/model/query/socialBookQuery.ts
+++ b/server/src/model/query/socialBookQuery.ts
@@ -40,6 +40,10 @@ const socialBookQuery = {
   READ_BELONG_SOCIAL_BOOK_LIST: `SELECT accountbook_id FROM social_accountbook_users WHERE user_id = ? AND state = 2 OR state = 0;`,
   CREATE_SOCIAL_TRANSACTION:
     'INSERT INTO social_transaction (accountbook_id, user_id, category_id, payment_id, date, title, amount) VALUES(?,?,?,?,?,?,?)',
+  READ_MONTHLY_STATISTICS_EXPEND: `SELECT SUM(amount) from social_transaction 
+  where accountbook_id = ? AND date >= ? AND date < ? AND payment_id IS NOT NULL`,
+  READ_MONTHLY_STATISTICS_INCOME: `SELECT SUM(amount) from social_transaction 
+  where accountbook_id = ? AND date >= ? AND date < ? AND payment_id IS NULL`,
 };
 
 export default socialBookQuery;

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -1,7 +1,9 @@
+/* eslint-disable no-await-in-loop */
 import { Context } from 'koa';
 import * as response from '../utils/response';
 import 'dotenv/config';
 import * as Service from './service';
+import { getPastMonthList } from '../utils/date';
 
 export const getSocialBooks = async (ctx: Context) => {
   const userId = ctx.userData.uid;
@@ -40,6 +42,19 @@ export const createTransaction = async (ctx: any) => {
   response.success(ctx, result);
 };
 
-export const getMonthlyStatistics = async (ctx: any) => {
-  response.success(ctx, 1234);
+export const getPastFourMonthStatistics = async (ctx: any) => {
+  const { bookId } = ctx.params;
+  const dateList = getPastMonthList(4);
+  const result: number[][] = [];
+
+  for (const date of dateList) {
+    const startDate = date[0];
+    const endDate = date[1];
+
+    const expend = await Service.getMonthlyStatisticsExpend(bookId, startDate, endDate);
+    const income = await Service.getMonthlyStatisticsIncome(bookId, startDate, endDate);
+
+    result.push([income, expend]);
+  }
+  response.success(ctx, result);
 };

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -39,3 +39,7 @@ export const createTransaction = async (ctx: any) => {
   const result = await Service.createTransaction(transaction);
   response.success(ctx, result);
 };
+
+export const getMonthlyStatistics = async (ctx: any) => {
+  response.success(ctx, 1234);
+};

--- a/server/src/socialBook/router.ts
+++ b/server/src/socialBook/router.ts
@@ -12,6 +12,6 @@ router.get('/transaction/:bookId/:date', Controller.getDailyTransaction);
 
 router.post('/transaction', Controller.createTransaction);
 
-router.get('/statistics/monthly', Controller.getMonthlyStatistics);
+router.get('/statistics/monthly/:bookId', Controller.getPastFourMonthStatistics);
 
 export default router;

--- a/server/src/socialBook/router.ts
+++ b/server/src/socialBook/router.ts
@@ -12,4 +12,6 @@ router.get('/transaction/:bookId/:date', Controller.getDailyTransaction);
 
 router.post('/transaction', Controller.createTransaction);
 
+router.get('/statistics/monthly', Controller.getMonthlyStatistics);
+
 export default router;

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -50,3 +50,30 @@ export const createTransaction = async (transaction: (string | number)[]) => {
   const result = await sql(query.CREATE_SOCIAL_TRANSACTION, transaction);
   return result.insertId;
 };
+
+export const getMonthlyStatisticsExpend = async (
+  accountBookId: number,
+  startDate: string,
+  endDate: string,
+) => {
+  const result = await sql(query.READ_MONTHLY_STATISTICS_EXPEND, [
+    accountBookId,
+    startDate,
+    endDate,
+  ]);
+
+  return result[0]['SUM(amount)'];
+};
+
+export const getMonthlyStatisticsIncome = async (
+  accountBookId: number,
+  startDate: string,
+  endDate: string,
+) => {
+  const result = await sql(query.READ_MONTHLY_STATISTICS_INCOME, [
+    accountBookId,
+    startDate,
+    endDate,
+  ]);
+  return result[0]['SUM(amount)'];
+};

--- a/server/src/utils/date.ts
+++ b/server/src/utils/date.ts
@@ -1,0 +1,19 @@
+// eslint-disable-next-line import/prefer-default-export
+export const getPastMonthList = (count: number) => {
+  const date = new Date();
+  const result = [];
+  let year = date.getFullYear();
+  let month = date.getMonth() + 1;
+  for (let index = 0; index < count; index += 1) {
+    if (month === 12) result.push([`${year}-${month}-1`, `${year + 1}-1-1`]);
+    else result.push([`${year}-${month}-1`, `${year}-${month + 1}-1`]);
+
+    if (month === 1) {
+      year -= 1;
+      month = 12;
+    } else {
+      month -= 1;
+    }
+  }
+  return result;
+};


### PR DESCRIPTION
### 📕 Issue Number

Close #100 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- `/api/social/statistics/monthly/:bookId` 로 접근
- 실행 결과 `[수입,지출]` 쌍의 내림차순 배열을 4개 반환
![image](https://user-images.githubusercontent.com/55074799/101389294-8ccf9980-3904-11eb-868f-fd3283bd488c.png)

- utils/date 파일에 날짜 계산 함수 구현
- socialbook query문 추가
<br/>

### 📘 작업 유형

- 신규 기능 추가

### 📘 참고사항

- JS의 forEach와 같은 반복문의 경우 내부에서 await이 선언 되는걸 비권장 하거나, 비동기적으로 작동하도록 되어있음
