### PR TITLE
Be feat statistic category api

### DIFF
--- a/server/src/interface/social.ts
+++ b/server/src/interface/social.ts
@@ -21,3 +21,8 @@ export interface SocialInfo {
   expenditureSum: string;
   images?: userImages;
 }
+
+export interface CategorySumData {
+  money: string;
+  name: string;
+}

--- a/server/src/model/query/privateBookQuery.ts
+++ b/server/src/model/query/privateBookQuery.ts
@@ -8,6 +8,18 @@ const privateBookQuery = {
     LEFT OUTER JOIN payment as py ON py.id = pt.payment_id 
     WHERE pt.accountbook_id = ? AND year(pt.date) = ? AND month(pt.date) = ? ORDER BY pt.date`,
   GET_PRIVATE_BOOK_ID: `SELECT id FROM private_accountbook WHERE user_id = ?`,
+  READ_PRIVATE_INCOME_CATEGORY: `
+    SELECT SUM(amount) as money,
+    (SELECT name FROM category WHERE category.id = private_transaction.category_id) as name
+    FROM private_transaction
+    WHERE accountbook_id = ? AND year(date) = ? AND month(date) = ? AND payment_id IS NULL
+    GROUP BY category_id ORDER BY SUM(amount) DESC;`,
+  READ_PRIVATE_EXPENDITURE_CATEGORY: `
+    SELECT SUM(amount) as money,
+    (SELECT name FROM category WHERE category.id = private_transaction.category_id) as name
+    FROM private_transaction
+    WHERE accountbook_id = ? AND year(date) = ? AND month(date) = ? AND payment_id IS NOT NULL
+    GROUP BY category_id ORDER BY SUM(amount) DESC;`,
 };
 
 export default privateBookQuery;

--- a/server/src/model/query/socialBookQuery.ts
+++ b/server/src/model/query/socialBookQuery.ts
@@ -32,12 +32,23 @@ const socialBookQuery = {
     SELECT picture FROM users WHERE id IN
     (SELECT user_id FROM social_accountbook_users WHERE (state = 0 OR state = 2) AND accountbook_id = ?)
     LIMIT 3;`,
-
   READ_DAILY_SOCIAL_BOOK: `SELECT st.id, ct.name as category, py.name as payment , st.title, st.amount,  st.date from social_transaction as st
-  JOIN category as ct on st.category_id = ct.id
-  LEFT OUTER JOIN  payment as py on py.id = st.payment_id
-  where st.accountbook_id = ? AND date(st.date) = date(?)`,
+    JOIN category as ct on st.category_id = ct.id
+    LEFT OUTER JOIN  payment as py on py.id = st.payment_id
+    WHERE st.accountbook_id = ? AND date(st.date) = date(?)`,
   READ_BELONG_SOCIAL_BOOK_LIST: `SELECT accountbook_id FROM social_accountbook_users WHERE user_id = ? AND state = 2 OR state = 0;`,
+  READ_SOCIAL_INCOME_CATEGORY: `
+    SELECT SUM(amount) as money,
+    (SELECT name FROM category WHERE category.id = social_transaction.category_id) as name
+    FROM social_transaction
+    WHERE accountbook_id = ? AND year(date) = ? AND month(date) = ? AND payment_id IS NULL
+    GROUP BY category_id ORDER BY SUM(amount) DESC;`,
+  READ_SOCIAL_EXPENDITURE_CATEGORY: `
+    SELECT SUM(amount) as money,
+    (SELECT name FROM category WHERE category.id = social_transaction.category_id) as name
+    FROM social_transaction
+    WHERE accountbook_id = ? AND year(date) = ? AND month(date) = ? AND payment_id IS NOT NULL
+    GROUP BY category_id ORDER BY SUM(amount) DESC;`,
   CREATE_SOCIAL_TRANSACTION:
     'INSERT INTO social_transaction (accountbook_id, user_id, category_id, payment_id, date, title, amount) VALUES(?,?,?,?,?,?,?)',
 };

--- a/server/src/privateBook/controller.ts
+++ b/server/src/privateBook/controller.ts
@@ -32,3 +32,18 @@ export const getTransactionList = async (ctx: any) => {
   });
   response.success(ctx, result);
 };
+
+export const getCategoryStatistic = async (ctx: any) => {
+  const { year, month } = ctx.params;
+  const userId = ctx.userData.uid;
+  const bookId = await Service.getAccountBookId(userId);
+
+  const income = await Service.getIncomeCategory(bookId, year, month);
+  const expenditure = await Service.getExpenditureCategory(bookId, year, month);
+
+  const result = {
+    income,
+    expenditure,
+  };
+  response.success(ctx, result);
+};

--- a/server/src/privateBook/router.ts
+++ b/server/src/privateBook/router.ts
@@ -5,6 +5,9 @@ const Router = require('@koa/router');
 const router = new Router();
 
 router.get('/transaction/list/:year/:month', Controller.getTransactionList);
+
 router.post('/transaction', Controller.createTransaction);
+
+router.get('/statistic/category/:year/:month', Controller.getCategoryStatistic);
 
 export default router;

--- a/server/src/privateBook/service.ts
+++ b/server/src/privateBook/service.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import sql from '../model/db';
 import query from '../model/query';
+import { getCategoryPercentData } from '../utils/accountbook';
 
 export const createTransaction = async (transaction: (string | number)[]) => {
   const result = await sql(query.CREATE_PRIVATE_TRANSACTION, transaction);
@@ -15,4 +16,16 @@ export const getTransactionList = async (searchInfo: (string | number)[]) => {
 export const getAccountBookId = async (userInfo: string) => {
   const [result] = await sql(query.GET_PRIVATE_BOOK_ID, [userInfo]);
   return result.id;
+};
+
+export const getIncomeCategory = async (bookId: number, year: number, month: number) => {
+  const result = await sql(query.READ_PRIVATE_INCOME_CATEGORY, [bookId, year, month]);
+  const percentResult = getCategoryPercentData(result);
+  return percentResult;
+};
+
+export const getExpenditureCategory = async (bookId: number, year: number, month: number) => {
+  const result = await sql(query.READ_PRIVATE_EXPENDITURE_CATEGORY, [bookId, year, month]);
+  const percentResult = getCategoryPercentData(result);
+  return percentResult;
 };

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -1,5 +1,6 @@
 import { Context } from 'koa';
 import * as response from '../utils/response';
+import message from '../utils/message';
 import 'dotenv/config';
 import * as Service from './service';
 
@@ -24,7 +25,7 @@ export const getDailyTransaction = async (ctx: Context) => {
   const bookIdList = await Service.getBelongSocialBookList(userId);
 
   if (!bookIdList.includes(Number(bookId))) {
-    response.fail(ctx, 403, 'You are not authorized to this account book');
+    response.fail(ctx, 403, message.NO_SOCIAL_AUTHORIZED);
     return;
   }
 
@@ -37,5 +38,26 @@ export const createTransaction = async (ctx: any) => {
   const { accountbookId, userId, categoryId, paymentId, date, title, amount } = ctx.request.body;
   const transaction = [accountbookId, userId, categoryId, paymentId, date, title, amount];
   const result = await Service.createTransaction(transaction);
+  response.success(ctx, result);
+};
+
+export const getCategoryStatistic = async (ctx: any) => {
+  const { bookId, year, month } = ctx.params;
+  const userId = ctx.userData.uid;
+
+  const bookIdList = await Service.getBelongSocialBookList(userId);
+
+  if (!bookIdList.includes(Number(bookId))) {
+    response.fail(ctx, 403, message.NO_SOCIAL_AUTHORIZED);
+    return;
+  }
+
+  const income = await Service.getIncomeCategory(bookId, year, month);
+  const expenditure = await Service.getExpenditureCategory(bookId, year, month);
+
+  const result = {
+    income,
+    expenditure,
+  };
   response.success(ctx, result);
 };

--- a/server/src/socialBook/router.ts
+++ b/server/src/socialBook/router.ts
@@ -12,4 +12,6 @@ router.get('/transaction/:bookId/:date', Controller.getDailyTransaction);
 
 router.post('/transaction', Controller.createTransaction);
 
+router.get('/statistic/category/:bookId/:year/:month', Controller.getCategoryStatistic);
+
 export default router;

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import sql from '../model/db';
 import query from '../model/query';
 import { UserImage, SocialInfo, SocialBookId } from '../interface/social';
+import { getCategoryPercentData } from '../utils/accountbook';
 
 export const getSocialBooks = async (userId: number) => {
   const socialBookList = await sql(query.READ_SOCIAL_BOOK_LIST, [userId]);
@@ -49,4 +50,16 @@ export const getBelongSocialBookList = async (userId: number) => {
 export const createTransaction = async (transaction: (string | number)[]) => {
   const result = await sql(query.CREATE_SOCIAL_TRANSACTION, transaction);
   return result.insertId;
+};
+
+export const getIncomeCategory = async (bookId: number, year: number, month: number) => {
+  const result = await sql(query.READ_SOCIAL_INCOME_CATEGORY, [bookId, year, month]);
+  const percentResult = getCategoryPercentData(result);
+  return percentResult;
+};
+
+export const getExpenditureCategory = async (bookId: number, year: number, month: number) => {
+  const result = await sql(query.READ_SOCIAL_EXPENDITURE_CATEGORY, [bookId, year, month]);
+  const percentResult = getCategoryPercentData(result);
+  return percentResult;
 };

--- a/server/src/utils/accountbook.ts
+++ b/server/src/utils/accountbook.ts
@@ -1,0 +1,23 @@
+/* eslint-disable no-restricted-syntax */
+import { CategorySumData } from '../interface/social';
+
+export const getCategoryPercentData = (categoryData: CategorySumData[]) => {
+  const total = categoryData.reduce(function (pre, curr): number {
+    return pre + parseInt(curr.money, 10);
+  }, 0);
+
+  const result = [];
+
+  for (const data of categoryData) {
+    const money = parseInt(data.money, 10);
+    result.push({
+      name: data.name,
+      money,
+      percent: Math.round((money / total) * 1000) / 10,
+    });
+  }
+
+  return result;
+};
+
+export default getCategoryPercentData;

--- a/server/src/utils/accountbook.ts
+++ b/server/src/utils/accountbook.ts
@@ -2,9 +2,7 @@
 import { CategorySumData } from '../interface/social';
 
 export const getCategoryPercentData = (categoryData: CategorySumData[]) => {
-  const total = categoryData.reduce(function (pre, curr): number {
-    return pre + parseInt(curr.money, 10);
-  }, 0);
+  const total = categoryData.reduce((pre, cur) => pre + parseInt(cur.money, 10), 0);
 
   const result = [];
 

--- a/server/src/utils/message.ts
+++ b/server/src/utils/message.ts
@@ -1,0 +1,5 @@
+const errorMessage = {
+  NO_SOCIAL_AUTHORIZED: `You are not authorized to this account book`,
+};
+
+export default errorMessage;


### PR DESCRIPTION
### 📕 Issue Number

Close #96 BE - 카테고리별 분석 조회 API 구현
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 소셜 가계부 카테고리별 지출 통계 API 구현
> http://localhost:3000/api/social/statistic/category/:bookId/:year/:month
성공
```json
{
    "status": "success",
    "data": {
        "income": [
            {
                "name": "기타수입",
                "money": 8480,
                "percent": 45.4
            },
            {
                "name": "용돈",
                "money": 5400,
                "percent": 28.9
            },
            {
                "name": "사업수입",
                "money": 4804,
                "percent": 25.7
            }
        ],
        "expenditure": [
            {
                "name": "식비",
                "money": 95190,
                "percent": 100
            }
        ]
    }
}
```
실패 - 잘못된 가계부 요청
```json
{
    "status": "fail",
    "data": "You are not authorized to this account book"
}
```
- 개인 가계부 카테고리별 지출 통계 API 구현
> http://localhost:3000/api/private/statistic/category/:year/:month
```json
{
    "status": "success",
    "data": {
        "income": [
            {
                "name": "기타수입",
                "money": 40000,
                "percent": 66.7
            },
            {
                "name": "급여",
                "money": 20000,
                "percent": 33.3
            }
        ],
        "expenditure": [
            {
                "name": "카페/간식",
                "money": 20000,
                "percent": 100
            }
        ]
    }
}
```
- 각 API는 합계를 기준으로 내림차순 반환됩니다.

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>