### PR TITLE
FE-feat transaction edit page 구현

### DIFF
--- a/client/src/components/organisms/EditTransactionMenu/EditTransactionMenu.stories.tsx
+++ b/client/src/components/organisms/EditTransactionMenu/EditTransactionMenu.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import EditTransactionMenu from './EditTransactionMenu';
+
+export default {
+  title: 'Organisms/EditTransactionMenu',
+  component: EditTransactionMenu,
+};
+
+export const editTransactionMenu = (): JSX.Element => {
+  const onClick = () => {
+    return true;
+  };
+  return <EditTransactionMenu submit={onClick} remove={onClick} cancel={onClick} />;
+};
+
+editTransactionMenu.story = {
+  name: 'EditTransactionMenu',
+};

--- a/client/src/components/organisms/EditTransactionMenu/EditTransactionMenu.tsx
+++ b/client/src/components/organisms/EditTransactionMenu/EditTransactionMenu.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+import RoundLongButton from '@atoms/button/RoundLongButton';
+import myColor from '@theme/color';
+
+interface Props {
+  submit: () => void;
+  remove: () => void;
+  cancel: () => void;
+}
+
+const BottomDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  height: 120px;
+  margin: 0px -20px;
+`;
+
+const editTransactionMenu: React.FC<Props> = ({ submit, remove, cancel }: Props) => {
+  return (
+    <BottomDiv>
+      <RoundLongButton onClick={submit}>등록</RoundLongButton>
+      <RoundLongButton onClick={remove} backgroundColor={myColor.primary.reject}>
+        삭제
+      </RoundLongButton>
+      <RoundLongButton onClick={cancel} backgroundColor={myColor.primary.cancel}>
+        취소
+      </RoundLongButton>
+    </BottomDiv>
+  );
+};
+
+export default editTransactionMenu;

--- a/client/src/components/organisms/EditTransactionMenu/index.ts
+++ b/client/src/components/organisms/EditTransactionMenu/index.ts
@@ -1,0 +1,1 @@
+export { default } from './EditTransactionMenu';

--- a/client/src/views/TransactionEditPage.tsx
+++ b/client/src/views/TransactionEditPage.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+import TopNavBar from '@organisms/TopNavBar';
+import CenterContent from '@molecules/CenterContent';
+import TransactionForm from '@organisms/TransactionForm';
+import EditTransactionMenu from '@organisms/EditTransactionMenu';
+import { useHistory } from 'react-router-dom';
+
+const Container = styled.div`
+  margin: 40px 20px 0px;
+`;
+
+const TransactionPostPage: React.FC = () => {
+  const history = useHistory();
+  const cancel = () => {
+    history.go(-1);
+  };
+  const onClick = () => {
+    return true;
+  };
+
+  return (
+    <>
+      <CenterContent>
+        <TopNavBar />
+        <Container>
+          <TransactionForm onClick={onClick} />
+          <EditTransactionMenu submit={onClick} remove={onClick} cancel={cancel} />
+        </Container>
+      </CenterContent>
+    </>
+  );
+};
+
+export default TransactionPostPage;


### PR DESCRIPTION
### 📕 Issue Number

Close #94 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- transaction edit page를 구현함
![image](https://user-images.githubusercontent.com/50297117/101497860-c3fa8500-39ae-11eb-8836-f40484f2be45.png)
- 별도의 router 설정은 하지 않음
- 수정 페이지 구축을 위한 EditTransactionMenu organisms을 개발함

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 수정 페이지에 접속할 수 있는 별도의 router 설정을 하지 않았습니다.
- 내역 페이지와 달력 페이지 개발시 해당 컴포넌트로 이동할 수 있는 설정을 부탁드립니다.

<br/><br/>