### PR TITLE
FE-feat transaction list UI

### DIFF
--- a/client/src/components/molecules/DailyTotal/DailyTotal.stories.tsx
+++ b/client/src/components/molecules/DailyTotal/DailyTotal.stories.tsx
@@ -29,6 +29,8 @@ export const dailyTotal = ({ width, height }: Props): JSX.Element => {
       ExMoney={ExMoney}
       width={width}
       height={height}
+      month="2020-12"
+      date={3}
     />
   );
 };

--- a/client/src/components/molecules/DailyTotal/DailyTotal.stories.tsx
+++ b/client/src/components/molecules/DailyTotal/DailyTotal.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import MyColor from '@theme/color';
+import DailyTotal from './DailyTotal';
+
+interface Props {
+  width: string;
+  height: string;
+}
+
+export default {
+  title: 'Molecules/DailyTotal',
+  component: DailyTotal,
+};
+
+export const dailyTotal = ({ width, height }: Props): JSX.Element => {
+  const fontWeight = 'bold';
+  const fontSize = '15px';
+  const InMoney = 223100;
+  const ExMoney = 10300;
+  const InColor = MyColor.money.income;
+  const ExColor = MyColor.money.expenditure;
+  return (
+    <DailyTotal
+      fontWeight={fontWeight}
+      fontSize={fontSize}
+      InColor={InColor}
+      ExColor={ExColor}
+      InMoney={InMoney}
+      ExMoney={ExMoney}
+      width={width}
+      height={height}
+    />
+  );
+};
+
+dailyTotal.story = {
+  name: 'DailyTotal',
+};

--- a/client/src/components/molecules/DailyTotal/DailyTotal.tsx
+++ b/client/src/components/molecules/DailyTotal/DailyTotal.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import styled from 'styled-components';
+import Income from '@atoms/p/IncomeText';
+import Expenditure from '@atoms/p/ExpenditureText';
+import myColor from '@theme/color';
+
+interface Props extends ColorProps, SizeProps {
+  fontWeight: string;
+  fontSize: string;
+  InMoney: number;
+  ExMoney: number;
+  inCheck?: boolean;
+  exCheck?: boolean;
+}
+
+interface ColorProps {
+  InColor: string;
+  ExColor: string;
+}
+
+interface SizeProps {
+  width: string;
+  height: string;
+}
+
+const defaultProps = {
+  width: '400px',
+  height: '30px',
+  inCheck: true,
+  exCheck: true,
+};
+
+const DailyTotal = styled.div<SizeProps>`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
+  border: 1px solid pink;
+  border-radius: 3px;
+  font-size: 3px;
+  color: ${myColor.primary.cancel};
+`;
+
+const dailyTotal: React.FC<Props> = ({
+  fontWeight,
+  fontSize,
+  InColor,
+  ExColor,
+  InMoney,
+  ExMoney,
+  width,
+  height,
+}: Props) => {
+  return (
+    <DailyTotal width={width} height={height}>
+      <Income fontWeight={fontWeight} fontSize={fontSize} color={InColor} money={InMoney} />
+      <Expenditure fontWeight={fontWeight} fontSize={fontSize} color={ExColor} money={ExMoney} />
+    </DailyTotal>
+  );
+};
+
+DailyTotal.defaultProps = defaultProps;
+
+export default dailyTotal;

--- a/client/src/components/molecules/DailyTotal/DailyTotal.tsx
+++ b/client/src/components/molecules/DailyTotal/DailyTotal.tsx
@@ -9,8 +9,8 @@ interface Props extends ColorProps, SizeProps {
   fontSize: string;
   InMoney: number;
   ExMoney: number;
-  inCheck?: boolean;
-  exCheck?: boolean;
+  date: number;
+  month: string;
 }
 
 interface ColorProps {
@@ -26,14 +26,11 @@ interface SizeProps {
 const defaultProps = {
   width: '400px',
   height: '30px',
-  inCheck: true,
-  exCheck: true,
 };
 
 const DailyTotal = styled.div<SizeProps>`
   display: flex;
   flex-direction: row;
-  justify-content: flex-end;
   align-items: center;
   width: ${(props) => props.width};
   height: ${(props) => props.height};
@@ -41,6 +38,10 @@ const DailyTotal = styled.div<SizeProps>`
   border-radius: 3px;
   font-size: 3px;
   color: ${myColor.primary.cancel};
+`;
+
+const TitleDiv = styled.div`
+  flex: 1;
 `;
 
 const dailyTotal: React.FC<Props> = ({
@@ -52,9 +53,17 @@ const dailyTotal: React.FC<Props> = ({
   ExMoney,
   width,
   height,
+  month,
+  date,
 }: Props) => {
+  const dayString = `${month}-${String(date)}`;
+  const dateArray = ['일', '월', '화', '수', '목', '금', '토'];
+  const title = `${new Date(dayString).getMonth() + 1}월 ${String(date)}일   (${
+    dateArray[new Date(dayString).getDay()]
+  })`;
   return (
     <DailyTotal width={width} height={height}>
+      <TitleDiv>{title}</TitleDiv>
       <Income fontWeight={fontWeight} fontSize={fontSize} color={InColor} money={InMoney} />
       <Expenditure fontWeight={fontWeight} fontSize={fontSize} color={ExColor} money={ExMoney} />
     </DailyTotal>

--- a/client/src/components/molecules/DailyTotal/index.ts
+++ b/client/src/components/molecules/DailyTotal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DailyTotal';

--- a/client/src/components/molecules/DailyTransaction/DailyTransaction.stories.tsx
+++ b/client/src/components/molecules/DailyTransaction/DailyTransaction.stories.tsx
@@ -7,8 +7,19 @@ export default {
 };
 
 export const dailyTransaction = (): JSX.Element => {
-  const data = { category: '용돈', title: '심부름', amount: 30000, payment: null };
-  return <DailyTransaction data={data} />;
+  return (
+    <DailyTransaction
+      data={{
+        id: 1,
+        date: '2020-10-07T15:06:28.000Z',
+        inmoney: 40000,
+        exmoney: 0,
+        payment: null,
+        category: '기타수입',
+        title: 'test3',
+      }}
+    />
+  );
 };
 
 dailyTransaction.story = {

--- a/client/src/components/molecules/DailyTransaction/DailyTransaction.stories.tsx
+++ b/client/src/components/molecules/DailyTransaction/DailyTransaction.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import DailyTransaction from './DailyTransaction';
+
+export default {
+  title: 'Molecules/DailyTransaction',
+  component: DailyTransaction,
+};
+
+export const dailyTransaction = (): JSX.Element => {
+  const data = { category: '용돈', title: '심부름', amount: 30000, payment: null };
+  return <DailyTransaction data={data} />;
+};
+
+dailyTransaction.story = {
+  name: 'DailyTransaction',
+};

--- a/client/src/components/molecules/DailyTransaction/DailyTransaction.tsx
+++ b/client/src/components/molecules/DailyTransaction/DailyTransaction.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styled from 'styled-components';
+import TransactionInfo from '@molecules/TransactionInfo';
+
+interface Props {
+  data: dataProps;
+}
+
+interface dataProps {
+  category: string;
+  title: string;
+  amount: number;
+  payment: any;
+}
+
+const DailyTransaction = styled.div`
+  border: 0;
+`;
+
+const dailyTransaction: React.FC<Props> = ({ data }: Props) => {
+  return (
+    <DailyTransaction>
+      <TransactionInfo data={data} />
+    </DailyTransaction>
+  );
+};
+
+export default dailyTransaction;

--- a/client/src/components/molecules/DailyTransaction/DailyTransaction.tsx
+++ b/client/src/components/molecules/DailyTransaction/DailyTransaction.tsx
@@ -17,7 +17,12 @@ interface dataProps {
 }
 
 const DailyTransaction = styled.div`
-  border: 0;
+  border: 1px solid pink;
+  border-radius: 5px;
+  &:hover {
+    background-color: pink;
+    transform: scale(1.2);
+  }
 `;
 const dailyTransaction: React.FC<Props> = ({ data }: Props) => {
   let money = 0;

--- a/client/src/components/molecules/DailyTransaction/DailyTransaction.tsx
+++ b/client/src/components/molecules/DailyTransaction/DailyTransaction.tsx
@@ -7,20 +7,34 @@ interface Props {
 }
 
 interface dataProps {
+  id: number;
+  date: string;
+  inmoney: number;
+  exmoney: number;
   category: string;
   title: string;
-  amount: number;
   payment: any;
 }
 
 const DailyTransaction = styled.div`
   border: 0;
 `;
-
 const dailyTransaction: React.FC<Props> = ({ data }: Props) => {
+  let money = 0;
+  if (data.payment) {
+    money = data.exmoney;
+  } else {
+    money = data.inmoney;
+  }
+  const reformData = {
+    category: data.category,
+    title: data.title,
+    amount: money,
+    payment: data.payment,
+  };
   return (
     <DailyTransaction>
-      <TransactionInfo data={data} />
+      <TransactionInfo data={reformData} />
     </DailyTransaction>
   );
 };

--- a/client/src/components/molecules/DailyTransaction/index.ts
+++ b/client/src/components/molecules/DailyTransaction/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DailyTransaction';

--- a/client/src/components/molecules/DayBox/DayBox.tsx
+++ b/client/src/components/molecules/DayBox/DayBox.tsx
@@ -74,12 +74,12 @@ const dayBox: React.FC<Props> = ({
       {date !== 0 ? (
         <>
           {date}
-          {inCheck ? (
+          {inCheck && (
             <InText money={InMoney} fontWeight={fontWeight} fontSize={fontSize} color={InColor} />
-          ) : undefined}
-          {exCheck ? (
+          )}
+          {exCheck && (
             <ExText money={ExMoney} fontWeight={fontWeight} fontSize={fontSize} color={ExColor} />
-          ) : undefined}
+          )}
         </>
       ) : (
         <></>

--- a/client/src/components/molecules/TransactionInfo/TransactionInfo.tsx
+++ b/client/src/components/molecules/TransactionInfo/TransactionInfo.tsx
@@ -25,7 +25,7 @@ const TransactionInfo: React.FC<props> = ({ data }: props) => {
       justifyContent="space-between"
       alignItems="center"
       borderWidth="0px 0px 0.5px 0px"
-      borderStyle="solid"
+      borderStyle="0"
       padding="8px 0px 8px 0px"
     >
       <RowFlexContainer>

--- a/client/src/components/organisms/Calendar/Calendar.tsx
+++ b/client/src/components/organisms/Calendar/Calendar.tsx
@@ -56,7 +56,7 @@ const calendar: React.FC<Props> = ({ dateData, monthData }: Props) => {
   const monthlyData = new Map();
 
   monthData.forEach((e) => {
-    const day = new Date(e.date).getDay() - 1;
+    const day = new Date(e.date).getDate();
     if (monthlyData.has(day)) {
       const value = monthlyData.get(day);
       monthlyData.set(day, [(value[0] += e.inmoney), (value[1] += e.exmoney)]);
@@ -82,14 +82,12 @@ const calendar: React.FC<Props> = ({ dateData, monthData }: Props) => {
     };
     preprocessData.push(buffer);
   });
-
   preprocessData.map((ele) => {
     return Object.assign(allDay[ele.date + emptyDays - 1], ele);
   });
   const allArr = sliceArray(allDay, 7);
-
-  const onClick = (date) => {
-    openModal(`${date}Result`);
+  const onClick = (thisDay) => {
+    openModal(`${thisDay}Result`);
   };
   return (
     <Calendar>

--- a/client/src/components/organisms/DailyTransactionModal/DailyTransactionModal.tsx
+++ b/client/src/components/organisms/DailyTransactionModal/DailyTransactionModal.tsx
@@ -39,9 +39,9 @@ const StyledLink = styled(Link)`
 
 const DailyTransactionModal: React.FC<props> = ({ month, date }: props) => {
   const allTransactionList = useSelector((state: RootState) => state.transaction.transactionList);
-  const dada = `${month}-${String(date)}`;
+  const dayString = `${month}-${String(date)}`;
   const dateArray = ['일', '월', '화', '수', '목', '금', '토'];
-  const title = `${String(date)} 일   (${dateArray[new Date(dada).getDay()]})`;
+  const title = `${String(date)} 일   (${dateArray[new Date(dayString).getDay()]})`;
   const dailyData: Array<{
     id: number;
     category: string;
@@ -50,7 +50,7 @@ const DailyTransactionModal: React.FC<props> = ({ month, date }: props) => {
     amount: number;
   }> = [];
   allTransactionList.forEach((e: any) => {
-    if (new Date(e.date).getDay() - 1 === date) {
+    if (new Date(e.date).getDate() === date) {
       dailyData.push({
         id: e.id,
         category: e.category,

--- a/client/src/components/organisms/MonthTransaction/MonthTransaction.stories.tsx
+++ b/client/src/components/organisms/MonthTransaction/MonthTransaction.stories.tsx
@@ -5,9 +5,46 @@ export default {
   title: 'Organisms/MonthTransaction',
   component: MonthTransaction,
 };
-
+const tempdata = [
+  {
+    id: 1,
+    date: '2020-10-07T15:06:28.000Z',
+    inmoney: 15000,
+    exmoney: 0,
+    payment: null,
+    category: '기타수입',
+    title: 'test3',
+  },
+  {
+    id: 2,
+    date: '2020-10-07T17:06:28.000Z',
+    inmoney: 40000,
+    exmoney: 0,
+    payment: null,
+    category: '알바',
+    title: '알바비',
+  },
+  {
+    id: 3,
+    date: '2020-10-07T11:06:28.000Z',
+    inmoney: 0,
+    exmoney: 1220,
+    payment: '현금',
+    category: '떡볶이',
+    title: '간식구매',
+  },
+  {
+    id: 4,
+    date: '2020-10-07T19:06:28.000Z',
+    inmoney: 0,
+    exmoney: 12000,
+    payment: '신한',
+    category: '서적',
+    title: '책구매',
+  },
+];
 export const monthTransaction = (): JSX.Element => {
-  return <MonthTransaction dateData="2020-12" monthData={[]} />;
+  return <MonthTransaction dateData="2020-12" monthData={tempdata} />;
 };
 
 monthTransaction.story = {

--- a/client/src/components/organisms/MonthTransaction/MonthTransaction.stories.tsx
+++ b/client/src/components/organisms/MonthTransaction/MonthTransaction.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import MonthTransaction from './MonthTransaction';
+
+export default {
+  title: 'Organisms/MonthTransaction',
+  component: MonthTransaction,
+};
+
+export const monthTransaction = (): JSX.Element => {
+  return <MonthTransaction dateData="2020-12" monthData={[]} />;
+};
+
+monthTransaction.story = {
+  name: 'MonthTransaction',
+};

--- a/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
+++ b/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
@@ -23,20 +23,43 @@ const MonthTransaction = styled.div`
 
 const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
   monthData.sort((a, b): any => Number(new Date(b.date)) - Number(new Date(a.date)));
-
+  let nowData = monthData;
+  const incomeData: any[] = [];
+  const excomeData: any[] = [];
+  monthData.forEach((ele) => {
+    if (ele.payment) {
+      excomeData.push(ele);
+    } else {
+      incomeData.push(ele);
+    }
+  });
   const [inCheck, setInCheck] = useState(true);
   const [exCheck, setExCheck] = useState(true);
-  console.log(dateData);
+  console.log(inCheck, exCheck);
+  nowData = [];
+  if (inCheck && exCheck) {
+    nowData = monthData;
+  }
+  if (inCheck && !exCheck) {
+    nowData = incomeData;
+  }
+  if (!inCheck && exCheck) {
+    nowData = excomeData;
+  }
+  if (!inCheck && !exCheck) {
+    nowData = [];
+  }
+
   const getDailyMoney = (date, flag) => {
     let dailymoney = 0;
     if (flag === true) {
-      monthData.forEach((e) => {
+      nowData.forEach((e) => {
         if (date === new Date(e.date).getDate()) {
           dailymoney += e.inmoney;
         }
       });
     } else {
-      monthData.forEach((e) => {
+      nowData.forEach((e) => {
         if (date === new Date(e.date).getDate()) {
           dailymoney += e.exmoney;
         }
@@ -48,18 +71,18 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
   const getMonthMoney = (flag) => {
     let monthMoney = 0;
     if (flag === true) {
-      monthData.forEach((e) => {
+      nowData.forEach((e) => {
         monthMoney += e.inmoney;
       });
     } else {
-      monthData.forEach((e) => {
+      nowData.forEach((e) => {
         monthMoney += e.exmoney;
       });
     }
     return monthMoney;
   };
 
-  let first = 0;
+  let now = 0;
   return (
     <MonthTransaction>
       <MonthNav />
@@ -83,22 +106,22 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
           money={getMonthMoney(false)}
         />
       </Filter>
-      {monthData.map((info) => {
-        if (new Date(info.date).getDate() !== first) {
-          first = new Date(info.date).getDate();
+      {nowData.map((info) => {
+        if (new Date(info.date).getDate() !== now) {
+          now = new Date(info.date).getDate();
           return (
             <>
               <DailyTotal
                 fontWeight="bold"
                 fontSize="15px"
-                InMoney={getDailyMoney(first, true)}
-                ExMoney={getDailyMoney(first, false)}
+                InMoney={getDailyMoney(now, true)}
+                ExMoney={getDailyMoney(now, false)}
                 InColor={Color.money.income}
                 ExColor={Color.money.expenditure}
                 width="100%"
                 height="2rem"
-                month="2020-10"
-                date={first}
+                month={dateData}
+                date={now}
               />
               <DailyTransaction data={info} />
             </>

--- a/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
+++ b/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
@@ -10,6 +10,7 @@ import Color from '@theme/color';
 // import { showModal } from '@actions/modal/type';
 // import { useSelector, useDispatch } from 'react-redux';
 // import { RootState } from '@reducers/rootReducer';
+import DailyTotal from '@molecules/DailyTotal';
 
 interface Props {
   dateData: string;
@@ -91,6 +92,18 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
           money={allDay.reduce((acc, cur) => acc + cur.exmoney, 0)}
         />
       </Filter>
+      <DailyTotal
+        fontWeight="bold"
+        fontSize="15px"
+        InMoney={12345}
+        ExMoney={33321}
+        InColor={Color.money.income}
+        ExColor={Color.money.expenditure}
+        width="100%"
+        height="2rem"
+        month="2020-12"
+        date={3}
+      />
     </MonthTransaction>
   );
 };

--- a/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
+++ b/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
@@ -1,15 +1,8 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import firstDayOfWeek from '@utils/firstDayOfWeek';
-import numberOfMonth from '@utils/numberOfMonth';
-import makeMonth from '@utils/makeMonth';
 import MonthNav from '@molecules/MonthNav';
 import CheckBoxWithNumber from '@molecules/CheckBoxWithNumber';
 import Color from '@theme/color';
-// import sliceArray from '@utils/sliceArray';
-// import { showModal } from '@actions/modal/type';
-// import { useSelector, useDispatch } from 'react-redux';
-// import { RootState } from '@reducers/rootReducer';
 import DailyTotal from '@molecules/DailyTotal';
 import DailyTransaction from '@molecules/DailyTransaction';
 
@@ -29,48 +22,20 @@ const MonthTransaction = styled.div`
 `;
 
 const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
-  // const dispatch = useDispatch();
-  // const modalView = useSelector((state: RootState) => state.modal.view);
-  // const openModal = (view: string) => {
-  //   dispatch(showModal(view));
-  // };
-  const monthlyData = new Map();
+  monthData.sort((a, b): any => Number(new Date(b.date)) - Number(new Date(a.date)));
 
-  monthData.forEach((e) => {
-    const day = new Date(e.date).getDate();
-    if (monthlyData.has(day)) {
-      const value = monthlyData.get(day);
-      monthlyData.set(day, [(value[0] += e.inmoney), (value[1] += e.exmoney)]);
-    } else {
-      monthlyData.set(day, [e.inmoney, e.exmoney]);
-    }
-  });
-
-  const firstDay = firstDayOfWeek(dateData);
-  const isSunday = 0;
-  const endDays = numberOfMonth(dateData);
   const [inCheck, setInCheck] = useState(true);
   const [exCheck, setExCheck] = useState(true);
-  const emptyDays = firstDay - isSunday < 0 ? 6 : firstDay - isSunday;
-  const allDay = makeMonth([], emptyDays, endDays);
-
-  const preprocessData: Array<{ date: number; inmoney: number; exmoney: number }> = [];
-  monthlyData.forEach((value, key) => {
-    const buffer: { date: number; inmoney: number; exmoney: number } = {
-      date: key,
-      inmoney: value[0],
-      exmoney: value[1],
-    };
-    preprocessData.push(buffer);
-  });
-  preprocessData.map((ele) => {
-    return Object.assign(allDay[ele.date + emptyDays - 1], ele);
-  });
-  // const allArr = sliceArray(allDay, 7);
-  // const onClick = (thisDay) => {
-  //   openModal(`${thisDay}Result`);
+  console.log(dateData);
+  // const getDailyMoney = (date, inmoney) => {
+  //   monthData.forEach((e) => {
+  //     if (date === new Date(e.date).getDate()) {
+  //       dailymoney += e.inmoney;
+  //     }
+  //   });
   // };
-  const temptemp = { category: '용돈', title: '심부름', amount: 30000, payment: null };
+
+  let first = 0;
   return (
     <MonthTransaction>
       <MonthNav />
@@ -82,7 +47,7 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
           onClick={() => setInCheck(!inCheck)}
           fontWeight="bold"
           fontSize="15px"
-          money={allDay.reduce((acc, cur) => acc + cur.inmoney, 0)}
+          money={2}
         />
         <CheckBoxWithNumber
           checked={exCheck}
@@ -91,22 +56,32 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
           onClick={() => setExCheck(!exCheck)}
           fontWeight="bold"
           fontSize="15px"
-          money={allDay.reduce((acc, cur) => acc + cur.exmoney, 0)}
+          money={1}
         />
       </Filter>
-      <DailyTotal
-        fontWeight="bold"
-        fontSize="15px"
-        InMoney={12345}
-        ExMoney={33321}
-        InColor={Color.money.income}
-        ExColor={Color.money.expenditure}
-        width="100%"
-        height="2rem"
-        month="2020-12"
-        date={3}
-      />
-      <DailyTransaction data={temptemp} />
+      {monthData.map((info) => {
+        if (new Date(info.date).getDate() !== first) {
+          first = new Date(info.date).getDate();
+          return (
+            <>
+              <DailyTotal
+                fontWeight="bold"
+                fontSize="15px"
+                InMoney={12345}
+                ExMoney={33321}
+                InColor={Color.money.income}
+                ExColor={Color.money.expenditure}
+                width="100%"
+                height="2rem"
+                month="2020-10"
+                date={first}
+              />
+              <DailyTransaction data={info} />
+            </>
+          );
+        }
+        return <DailyTransaction data={info} />;
+      })}
     </MonthTransaction>
   );
 };

--- a/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
+++ b/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
@@ -11,6 +11,7 @@ import Color from '@theme/color';
 // import { useSelector, useDispatch } from 'react-redux';
 // import { RootState } from '@reducers/rootReducer';
 import DailyTotal from '@molecules/DailyTotal';
+import DailyTransaction from '@molecules/DailyTransaction';
 
 interface Props {
   dateData: string;
@@ -69,6 +70,7 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
   // const onClick = (thisDay) => {
   //   openModal(`${thisDay}Result`);
   // };
+  const temptemp = { category: '용돈', title: '심부름', amount: 30000, payment: null };
   return (
     <MonthTransaction>
       <MonthNav />
@@ -104,6 +106,7 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
         month="2020-12"
         date={3}
       />
+      <DailyTransaction data={temptemp} />
     </MonthTransaction>
   );
 };

--- a/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
+++ b/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
@@ -27,13 +27,37 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
   const [inCheck, setInCheck] = useState(true);
   const [exCheck, setExCheck] = useState(true);
   console.log(dateData);
-  // const getDailyMoney = (date, inmoney) => {
-  //   monthData.forEach((e) => {
-  //     if (date === new Date(e.date).getDate()) {
-  //       dailymoney += e.inmoney;
-  //     }
-  //   });
-  // };
+  const getDailyMoney = (date, flag) => {
+    let dailymoney = 0;
+    if (flag === true) {
+      monthData.forEach((e) => {
+        if (date === new Date(e.date).getDate()) {
+          dailymoney += e.inmoney;
+        }
+      });
+    } else {
+      monthData.forEach((e) => {
+        if (date === new Date(e.date).getDate()) {
+          dailymoney += e.exmoney;
+        }
+      });
+    }
+    return dailymoney;
+  };
+
+  const getMonthMoney = (flag) => {
+    let monthMoney = 0;
+    if (flag === true) {
+      monthData.forEach((e) => {
+        monthMoney += e.inmoney;
+      });
+    } else {
+      monthData.forEach((e) => {
+        monthMoney += e.exmoney;
+      });
+    }
+    return monthMoney;
+  };
 
   let first = 0;
   return (
@@ -47,7 +71,7 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
           onClick={() => setInCheck(!inCheck)}
           fontWeight="bold"
           fontSize="15px"
-          money={2}
+          money={getMonthMoney(true)}
         />
         <CheckBoxWithNumber
           checked={exCheck}
@@ -56,7 +80,7 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
           onClick={() => setExCheck(!exCheck)}
           fontWeight="bold"
           fontSize="15px"
-          money={1}
+          money={getMonthMoney(false)}
         />
       </Filter>
       {monthData.map((info) => {
@@ -67,8 +91,8 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
               <DailyTotal
                 fontWeight="bold"
                 fontSize="15px"
-                InMoney={12345}
-                ExMoney={33321}
+                InMoney={getDailyMoney(first, true)}
+                ExMoney={getDailyMoney(first, false)}
                 InColor={Color.money.income}
                 ExColor={Color.money.expenditure}
                 width="100%"

--- a/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
+++ b/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
@@ -33,6 +33,7 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
       incomeData.push(ele);
     }
   });
+
   const [inCheck, setInCheck] = useState(true);
   const [exCheck, setExCheck] = useState(true);
   if (inCheck && exCheck) {
@@ -69,11 +70,11 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
   const getMonthMoney = (flag) => {
     let monthMoney = 0;
     if (flag === true) {
-      nowData.forEach((e) => {
+      monthData.forEach((e) => {
         monthMoney += e.inmoney;
       });
     } else {
-      nowData.forEach((e) => {
+      monthData.forEach((e) => {
         monthMoney += e.exmoney;
       });
     }

--- a/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
+++ b/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
@@ -8,7 +8,7 @@ import DailyTransaction from '@molecules/DailyTransaction';
 
 interface Props {
   dateData: string;
-  monthData: any;
+  monthData: any[];
 }
 
 const Filter = styled.div`
@@ -17,13 +17,13 @@ const Filter = styled.div`
 `;
 
 const MonthTransaction = styled.div`
-  border: 2px solid pink;
+  border: 1px solid pink;
   border-radius: 5px;
 `;
 
 const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
   monthData.sort((a, b): any => Number(new Date(b.date)) - Number(new Date(a.date)));
-  let nowData = monthData;
+  let nowData: any[] = monthData;
   const incomeData: any[] = [];
   const excomeData: any[] = [];
   monthData.forEach((ele) => {
@@ -35,8 +35,6 @@ const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
   });
   const [inCheck, setInCheck] = useState(true);
   const [exCheck, setExCheck] = useState(true);
-  console.log(inCheck, exCheck);
-  nowData = [];
   if (inCheck && exCheck) {
     nowData = monthData;
   }

--- a/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
+++ b/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import firstDayOfWeek from '@utils/firstDayOfWeek';
+import numberOfMonth from '@utils/numberOfMonth';
+import makeMonth from '@utils/makeMonth';
+import MonthNav from '@molecules/MonthNav';
+import CheckBoxWithNumber from '@molecules/CheckBoxWithNumber';
+import Color from '@theme/color';
+// import sliceArray from '@utils/sliceArray';
+// import { showModal } from '@actions/modal/type';
+// import { useSelector, useDispatch } from 'react-redux';
+// import { RootState } from '@reducers/rootReducer';
+
+interface Props {
+  dateData: string;
+  monthData: any;
+}
+
+const Filter = styled.div`
+  display: flex;
+  justify-content: space-around;
+`;
+
+const MonthTransaction = styled.div`
+  border: 2px solid pink;
+  border-radius: 5px;
+`;
+
+const monthTransaction: React.FC<Props> = ({ dateData, monthData }: Props) => {
+  // const dispatch = useDispatch();
+  // const modalView = useSelector((state: RootState) => state.modal.view);
+  // const openModal = (view: string) => {
+  //   dispatch(showModal(view));
+  // };
+  const monthlyData = new Map();
+
+  monthData.forEach((e) => {
+    const day = new Date(e.date).getDate();
+    if (monthlyData.has(day)) {
+      const value = monthlyData.get(day);
+      monthlyData.set(day, [(value[0] += e.inmoney), (value[1] += e.exmoney)]);
+    } else {
+      monthlyData.set(day, [e.inmoney, e.exmoney]);
+    }
+  });
+
+  const firstDay = firstDayOfWeek(dateData);
+  const isSunday = 0;
+  const endDays = numberOfMonth(dateData);
+  const [inCheck, setInCheck] = useState(true);
+  const [exCheck, setExCheck] = useState(true);
+  const emptyDays = firstDay - isSunday < 0 ? 6 : firstDay - isSunday;
+  const allDay = makeMonth([], emptyDays, endDays);
+
+  const preprocessData: Array<{ date: number; inmoney: number; exmoney: number }> = [];
+  monthlyData.forEach((value, key) => {
+    const buffer: { date: number; inmoney: number; exmoney: number } = {
+      date: key,
+      inmoney: value[0],
+      exmoney: value[1],
+    };
+    preprocessData.push(buffer);
+  });
+  preprocessData.map((ele) => {
+    return Object.assign(allDay[ele.date + emptyDays - 1], ele);
+  });
+  // const allArr = sliceArray(allDay, 7);
+  // const onClick = (thisDay) => {
+  //   openModal(`${thisDay}Result`);
+  // };
+  return (
+    <MonthTransaction>
+      <MonthNav />
+      <Filter>
+        <CheckBoxWithNumber
+          checked={inCheck}
+          color={Color.money.income}
+          description="수입"
+          onClick={() => setInCheck(!inCheck)}
+          fontWeight="bold"
+          fontSize="15px"
+          money={allDay.reduce((acc, cur) => acc + cur.inmoney, 0)}
+        />
+        <CheckBoxWithNumber
+          checked={exCheck}
+          color={Color.money.expenditure}
+          description="지출"
+          onClick={() => setExCheck(!exCheck)}
+          fontWeight="bold"
+          fontSize="15px"
+          money={allDay.reduce((acc, cur) => acc + cur.exmoney, 0)}
+        />
+      </Filter>
+    </MonthTransaction>
+  );
+};
+
+export default monthTransaction;

--- a/client/src/components/organisms/MonthTransaction/index.ts
+++ b/client/src/components/organisms/MonthTransaction/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MonthTransaction';

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -2,9 +2,9 @@ import 'dotenv/config';
 
 export const GET_JWT = `${process.env.REACT_APP_BASE_URL}/login/`;
 
-export const GET_TRANSACTION_SOCIAL_LIST = `${process.env.REACT_APP_BASE_URL}/social/transaction/list`;
+export const GET_TRANSACTION_SOCIAL_LIST = `${process.env.REACT_APP_BASE_URL}/api/social/transaction/list`;
 
-export const GET_TRANSACTION_PRIVATE_LIST = `${process.env.REACT_APP_BASE_URL}/private/transaction/list`;
+export const GET_TRANSACTION_PRIVATE_LIST = `${process.env.REACT_APP_BASE_URL}/api/private/transaction/list`;
 
 export const GET_USER_NAME = `${process.env.REACT_APP_BASE_URL}/api/user/name`;
 

--- a/client/src/views/CalendarPage.tsx
+++ b/client/src/views/CalendarPage.tsx
@@ -4,58 +4,41 @@ import Calendar from '@organisms/Calendar';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
 import { getTransaction } from '@actions/transaction/type';
-// import { getAxiosData } from '@utils/axios';
-// import * as API from '@utils/api';
+import { getAxiosData } from '@utils/axios';
+import * as API from '@utils/api';
 
 const CalendarPage: React.FC = () => {
   const year = useSelector((state: RootState) => state.date.year);
   const month = useSelector((state: RootState) => state.date.month);
   const transactionList = useSelector((state: RootState) => state.transaction.transactionList);
+  const accountbookType = useSelector((state: RootState) => state.accountbook.type);
+  const accountbookId = useSelector((state: RootState) => state.accountbook.socialId);
   const dateData = `${year}-${month}`;
   const dispatch = useDispatch();
   const changeTransaction = (newList: any) => {
     dispatch(getTransaction(newList));
   };
   useEffect(() => {
-    // const getTransactionList = async () => {
-    //   if (account === 'social') {
-    //     const result = await getAxiosData(`${API.GET_TRANSACTION_SOCIAL_LIST}/${accountbook_id}/${year}/${month}`)
-    //     return result;
-    //   }
-    // };
-    // (async () => {
-    //   const { data } = await getTransactionList();
-    //   changeTransaction(data);
-    // })();
-    changeTransaction([
-      {
-        id: 1,
-        date: '2020-12-02T13:10:44.000Z',
-        inmoney: 1222,
-        exmoney: 0,
-        payment: null,
-        category: '용돈',
-        title: '아빠',
-      },
-      {
-        id: 2,
-        date: '2020-12-02T13:10:44.000Z',
-        inmoney: 0,
-        exmoney: 123,
-        payment: '신한카드',
-        category: '마트',
-        title: '소고기',
-      },
-      {
-        id: 3,
-        date: '2020-12-03T13:10:44.000Z',
-        inmoney: 0,
-        exmoney: 5000,
-        payment: '신한카드',
-        category: '마트',
-        title: '소고기',
-      },
-    ]);
+    // eslint-disable-next-line consistent-return
+    const getTransactionList = async (type: string): Promise<any> => {
+      let result;
+      switch (type) {
+        case 'PRIVATE':
+          result = await getAxiosData(`${API.GET_TRANSACTION_PRIVATE_LIST}/${year}/${month}`);
+          return result;
+        case 'SOCIAL':
+          result = await getAxiosData(
+            `${API.GET_TRANSACTION_SOCIAL_LIST}/${accountbookId}/${year}/${month}`,
+          );
+          return result;
+        default:
+          break;
+      }
+    };
+    (async () => {
+      const { data } = await getTransactionList(accountbookType);
+      changeTransaction(data);
+    })();
   }, [dateData]);
   return (
     <>

--- a/client/src/views/TransactionPage.tsx
+++ b/client/src/views/TransactionPage.tsx
@@ -3,9 +3,47 @@ import NewTransactionButton from '@organisms/NewTransactionButton';
 import MonthTransaction from '@organisms/MonthTransaction';
 
 const TransactionPage: React.FC = () => {
+  const tempdata = [
+    {
+      id: 1,
+      date: '2020-10-07T15:06:28.000Z',
+      inmoney: 40000,
+      exmoney: 0,
+      payment: null,
+      category: '기타수입',
+      title: 'test3',
+    },
+    {
+      id: 2,
+      date: '2020-10-07T17:06:28.000Z',
+      inmoney: 40000,
+      exmoney: 0,
+      payment: null,
+      category: '알바',
+      title: '알바비',
+    },
+    {
+      id: 3,
+      date: '2020-10-07T11:06:28.000Z',
+      inmoney: 0,
+      exmoney: 1220,
+      payment: '현금',
+      category: '떡볶이',
+      title: '간식구매',
+    },
+    {
+      id: 4,
+      date: '2020-10-07T19:06:28.000Z',
+      inmoney: 0,
+      exmoney: 12000,
+      payment: '신한',
+      category: '서적',
+      title: '책구매',
+    },
+  ];
   return (
     <>
-      <MonthTransaction dateData="2020-12" monthData={[]} />
+      <MonthTransaction dateData="2020-10" monthData={tempdata} />
       <NewTransactionButton />
     </>
   );

--- a/client/src/views/TransactionPage.tsx
+++ b/client/src/views/TransactionPage.tsx
@@ -7,7 +7,7 @@ const TransactionPage: React.FC = () => {
     {
       id: 1,
       date: '2020-10-07T15:06:28.000Z',
-      inmoney: 40000,
+      inmoney: 15000,
       exmoney: 0,
       payment: null,
       category: '기타수입',

--- a/client/src/views/TransactionPage.tsx
+++ b/client/src/views/TransactionPage.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import NewTransactionButton from '@organisms/NewTransactionButton';
+import MonthTransaction from '@organisms/MonthTransaction';
 
 const TransactionPage: React.FC = () => {
   return (
     <>
-      <p>this is TransactionPage</p>
+      <MonthTransaction dateData="2020-12" monthData={[]} />
       <NewTransactionButton />
     </>
   );

--- a/client/src/views/TransactionPage.tsx
+++ b/client/src/views/TransactionPage.tsx
@@ -1,49 +1,48 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import NewTransactionButton from '@organisms/NewTransactionButton';
 import MonthTransaction from '@organisms/MonthTransaction';
+import { useSelector, useDispatch } from 'react-redux';
+import { RootState } from '@reducers/rootReducer';
+import { getTransaction } from '@actions/transaction/type';
+import { getAxiosData } from '@utils/axios';
+import * as API from '@utils/api';
 
 const TransactionPage: React.FC = () => {
-  const tempdata = [
-    {
-      id: 1,
-      date: '2020-10-07T15:06:28.000Z',
-      inmoney: 15000,
-      exmoney: 0,
-      payment: null,
-      category: '기타수입',
-      title: 'test3',
-    },
-    {
-      id: 2,
-      date: '2020-10-07T17:06:28.000Z',
-      inmoney: 40000,
-      exmoney: 0,
-      payment: null,
-      category: '알바',
-      title: '알바비',
-    },
-    {
-      id: 3,
-      date: '2020-10-07T11:06:28.000Z',
-      inmoney: 0,
-      exmoney: 1220,
-      payment: '현금',
-      category: '떡볶이',
-      title: '간식구매',
-    },
-    {
-      id: 4,
-      date: '2020-10-07T19:06:28.000Z',
-      inmoney: 0,
-      exmoney: 12000,
-      payment: '신한',
-      category: '서적',
-      title: '책구매',
-    },
-  ];
+  const year = useSelector((state: RootState) => state.date.year);
+  const month = useSelector((state: RootState) => state.date.month);
+  const transactionList = useSelector((state: RootState) => state.transaction.transactionList);
+  const accountbookType = useSelector((state: RootState) => state.accountbook.type);
+  const accountbookId = useSelector((state: RootState) => state.accountbook.socialId);
+  const dateData = `${year}-${month}`;
+  const dispatch = useDispatch();
+  const changeTransaction = (newList: any) => {
+    dispatch(getTransaction(newList));
+  };
+  useEffect(() => {
+    // eslint-disable-next-line consistent-return
+    const getTransactionList = async (type: string): Promise<any> => {
+      let result;
+      switch (type) {
+        case 'PRIVATE':
+          result = await getAxiosData(`${API.GET_TRANSACTION_PRIVATE_LIST}/${year}/${month}`);
+          return result;
+        case 'SOCIAL':
+          result = await getAxiosData(
+            `${API.GET_TRANSACTION_SOCIAL_LIST}/${accountbookId}/${year}/${month}`,
+          );
+          return result;
+        default:
+          break;
+      }
+    };
+    (async () => {
+      const { data } = await getTransactionList(accountbookType);
+      changeTransaction(data);
+    })();
+  }, [dateData]);
   return (
     <>
-      <MonthTransaction dateData="2020-10" monthData={tempdata} />
+      <MonthTransaction dateData={dateData} monthData={transactionList} />
       <NewTransactionButton />
     </>
   );


### PR DESCRIPTION
### 📕 Issue Number

Close #60 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- calendar page axios 연동
    - 연-월이 이동할때마다 api 를 요청하는 방식으로 구현

- molecules dailyTransaction 구현
    - ![](https://i.imgur.com/50ZRUbj.png)


- molecules dailyTotal 구현
    - ![](https://i.imgur.com/oaij20k.png)

- Organism MonthTransaction 구현
    - ![](https://i.imgur.com/SIHTt22.png)

- monthTransaction filter 구현

<br/>

### 📘 작업 유형

- 신규 기능 추가


<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- CSS 는 콜리타임을 위해 남겨두었습니다. ㅎㅎ
- 달력과 마찬가지로 연-월에 API를 요청하고, transactionList 를 스토어로 관리합니다. 

<br/><br/>