### PR TITLE
FE-feat-createAccountButton 가계부 생성 페이지 수정 및 생성 버튼 기능개발

### DIFF
--- a/client/src/components/atoms/textarea/TextArea/TextArea.tsx
+++ b/client/src/components/atoms/textarea/TextArea/TextArea.tsx
@@ -5,19 +5,55 @@ import myColor from '@theme/color';
 interface Props {
   width: string;
   height: string;
+  value?: string;
+  fontColor?: string;
+  backgroundColor?: string;
+  fontSize?: string;
+  onChange?: (event: any) => void;
 }
+
+const defaultProps = {
+  value: '',
+  backgroundColor: myColor.background.lightGray,
+  fontSize: '10pt',
+  fontColor: 'black',
+  onChange: undefined,
+};
 
 const TextArea = styled.textarea<Props>`
   width: ${(props) => props.width};
   height: ${(props) => props.height};
   resize: none;
   border: none;
-  background-color: ${myColor.background.lightGray};
+  background-color: ${(props) => props.backgroundColor};
   border-radius: 15px;
+  font-size: ${(props) => props.fontSize};
+  color: ${(props) => props.fontColor};
+  font-family: S-CoreDream-4Regular;
 `;
 
-const textArea: React.FC<Props> = ({ width, height }: Props) => {
-  return <TextArea width={width} height={height} />;
+const textArea: React.FC<Props> = ({
+  fontSize,
+  fontColor,
+  backgroundColor,
+  value,
+  width,
+  height,
+  onChange,
+}: Props) => {
+  return (
+    <TextArea
+      fontSize={fontSize}
+      fontColor={fontColor}
+      backgroundColor={backgroundColor}
+      onChange={onChange}
+      value={value}
+      width={width}
+      height={height}
+    />
+  );
 };
+
+textArea.defaultProps = defaultProps;
 
 export default textArea;

--- a/client/src/components/atoms/textarea/TextArea/TextArea.tsx
+++ b/client/src/components/atoms/textarea/TextArea/TextArea.tsx
@@ -9,6 +9,7 @@ interface Props {
   fontColor?: string;
   backgroundColor?: string;
   fontSize?: string;
+  placeholder?: string;
   onChange?: (event: any) => void;
 }
 
@@ -18,6 +19,7 @@ const defaultProps = {
   fontSize: '10pt',
   fontColor: 'black',
   onChange: undefined,
+  placeholder: '',
 };
 
 const TextArea = styled.textarea<Props>`
@@ -30,6 +32,10 @@ const TextArea = styled.textarea<Props>`
   font-size: ${(props) => props.fontSize};
   color: ${(props) => props.fontColor};
   font-family: S-CoreDream-4Regular;
+  placeholder : {
+    color: ${(props) => props.fontColor};
+    font-size: ${(props) => props.fontSize};
+  }
 `;
 
 const textArea: React.FC<Props> = ({
@@ -39,6 +45,7 @@ const textArea: React.FC<Props> = ({
   value,
   width,
   height,
+  placeholder,
   onChange,
 }: Props) => {
   return (
@@ -50,6 +57,7 @@ const textArea: React.FC<Props> = ({
       value={value}
       width={width}
       height={height}
+      placeholder={placeholder}
     />
   );
 };

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.stories.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.stories.tsx
@@ -7,8 +7,12 @@ export default {
   component: CreateAccountbookFormBox,
 };
 
+const testFunc = () => {
+  console.log('test');
+};
+
 export const createAccountbookFormBox = (): JSX.Element => {
-  return <CreateAccountbookFormBox backgroundColor={myColor.primary.main} />;
+  return <CreateAccountbookFormBox buttonEvent={testFunc} backgroundColor={myColor.primary.main} />;
 };
 
 createAccountbookFormBox.story = {

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.stories.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.stories.tsx
@@ -7,12 +7,18 @@ export default {
   component: CreateAccountbookFormBox,
 };
 
-const testFunc = () => {
-  console.log('test');
+const testFunc = (data: any) => {
+  console.log(data);
+  return data;
 };
 
 export const createAccountbookFormBox = (): JSX.Element => {
-  return <CreateAccountbookFormBox buttonEvent={testFunc} backgroundColor={myColor.primary.main} />;
+  return (
+    <CreateAccountbookFormBox
+      buttonEvent={testFunc('123')}
+      backgroundColor={myColor.primary.main}
+    />
+  );
 };
 
 createAccountbookFormBox.story = {

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
@@ -9,14 +9,14 @@ import colorUtils from '@utils/color';
 
 interface Props {
   backgroundColor: string;
-  buttonEvent(data): any;
+  buttonEvent: (data) => any;
 }
 
 const CreateAccountbookFormBox: React.FC<Props> = ({ buttonEvent, backgroundColor }: Props) => {
   const fontColor = colorUtils.getFontColor(backgroundColor);
   const buttonColor = fontColor === 'white' ? 'black' : 'white';
 
-  const [name, setName] = useState('이름을 입력해주세요');
+  const [name, setName] = useState();
   const [description, setDescription] = useState();
 
   const nameChangeHandler = (event: any) => {
@@ -44,7 +44,7 @@ const CreateAccountbookFormBox: React.FC<Props> = ({ buttonEvent, backgroundColo
             border="none"
             backgroundColor={buttonColor}
             color={fontColor}
-            onClick={buttonEvent(name)}
+            onClick={() => buttonEvent(name)}
           >
             생성
           </RoundShortButton>
@@ -58,6 +58,7 @@ const CreateAccountbookFormBox: React.FC<Props> = ({ buttonEvent, backgroundColo
             fontColor={fontColor}
             fontSize="17pt"
             backgroundColor={backgroundColor}
+            placeholder="이름을 입력해주세요."
           />
         </RowFlexContainer>
         <TextArea

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
@@ -6,14 +6,13 @@ import TextArea from '@atoms/textarea/TextArea';
 import SquircleCard from '@atoms/div/SquircleCard';
 import RoundShortButton from '@atoms/button/RoundShortButton';
 import colorUtils from '@utils/color';
-/* import * as Axios from '@utils/axios';
-import * as API from '@utils/api'; */
 
 interface Props {
   backgroundColor: string;
+  buttonEvent(data): any;
 }
 
-const CreateAccountbookFormBox: React.FC<Props> = ({ backgroundColor }: Props) => {
+const CreateAccountbookFormBox: React.FC<Props> = ({ buttonEvent, backgroundColor }: Props) => {
   const fontColor = colorUtils.getFontColor(backgroundColor);
   const buttonColor = fontColor === 'white' ? 'black' : 'white';
 
@@ -26,10 +25,6 @@ const CreateAccountbookFormBox: React.FC<Props> = ({ backgroundColor }: Props) =
 
   const descriptionChangeHandler = (event: any) => {
     setDescription(event.target.value);
-  };
-
-  const createButtonClick = () => {
-    console.log(name);
   };
 
   return (
@@ -49,7 +44,7 @@ const CreateAccountbookFormBox: React.FC<Props> = ({ backgroundColor }: Props) =
             border="none"
             backgroundColor={buttonColor}
             color={fontColor}
-            onClick={createButtonClick}
+            onClick={buttonEvent(name)}
           >
             생성
           </RoundShortButton>

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import LeftLargeText from '@atoms/p/LeftLargeText';
@@ -6,6 +6,8 @@ import TextArea from '@atoms/textarea/TextArea';
 import SquircleCard from '@atoms/div/SquircleCard';
 import RoundShortButton from '@atoms/button/RoundShortButton';
 import colorUtils from '@utils/color';
+/* import * as Axios from '@utils/axios';
+import * as API from '@utils/api'; */
 
 interface Props {
   backgroundColor: string;
@@ -14,6 +16,22 @@ interface Props {
 const CreateAccountbookFormBox: React.FC<Props> = ({ backgroundColor }: Props) => {
   const fontColor = colorUtils.getFontColor(backgroundColor);
   const buttonColor = fontColor === 'white' ? 'black' : 'white';
+
+  const [name, setName] = useState('이름을 입력해주세요');
+  const [description, setDescription] = useState();
+
+  const nameChangeHandler = (event: any) => {
+    setName(event.target.value);
+  };
+
+  const descriptionChangeHandler = (event: any) => {
+    setDescription(event.target.value);
+  };
+
+  const createButtonClick = () => {
+    console.log(name);
+  };
+
   return (
     <SquircleCard width="100%" backgroundColor={backgroundColor} height="15rem">
       <ColumnFlexContainer
@@ -27,14 +45,32 @@ const CreateAccountbookFormBox: React.FC<Props> = ({ backgroundColor }: Props) =
           <LeftLargeText color={fontColor} fontWeight="bold">
             가계부 생성
           </LeftLargeText>
-          <RoundShortButton border="none" backgroundColor={buttonColor} color={fontColor}>
+          <RoundShortButton
+            border="none"
+            backgroundColor={buttonColor}
+            color={fontColor}
+            onClick={createButtonClick}
+          >
             생성
           </RoundShortButton>
         </RowFlexContainer>
         <RowFlexContainer width="100%" justifyContent="baseline">
-          <LeftLargeText color={fontColor}>이름을 입력해주세요.</LeftLargeText>
+          <TextArea
+            value={name}
+            width="50%"
+            height="100%"
+            onChange={nameChangeHandler}
+            fontColor={fontColor}
+            fontSize="17pt"
+            backgroundColor={backgroundColor}
+          />
         </RowFlexContainer>
-        <TextArea width="100%" height="30%" />
+        <TextArea
+          value={description}
+          width="100%"
+          height="30%"
+          onChange={descriptionChangeHandler}
+        />
       </ColumnFlexContainer>
     </SquircleCard>
   );

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -17,3 +17,5 @@ export const GET_INCOME_CATEGORY = `${process.env.REACT_APP_BASE_URL}/api/catego
 export const GET_EXPENDITURE_CATEGORY = `${process.env.REACT_APP_BASE_URL}/api/category/expenditure`;
 
 export const GET_PAYMENT = `${process.env.REACT_APP_BASE_URL}/api/payment`;
+
+export const POST_CREATE_SOCIAL = `${process.env.REACT_APP_BASE_URL}/api/social/create`;

--- a/client/src/views/CreateAccountbookPage.tsx
+++ b/client/src/views/CreateAccountbookPage.tsx
@@ -6,15 +6,30 @@ import CreateAccountbookFormBox from '@organisms/CreateAccountbookFormBox';
 import TopNavBar from '@organisms/TopNavBar';
 import CreateAccountbookSetting from '@organisms/CreateAccountbookSetting';
 import colorUtils from '@utils/color';
+/* import * as Axios from '@utils/axios';
+import * as API from '@utils/api'; */
 
 const CreateAccountbookPage: React.FC = () => {
+  const createButtonClick = async (data: any) => {
+    /* const data = {
+      name,
+      description,
+      usersList,
+      color,
+    };
+    const result = await Axios.postAxios(API.POST_CREATE_SOCIAL, data); */
+    console.log(data);
+  };
   const backgroundColor = colorUtils.getRandomColor();
   return (
     <>
       <ColoredBackground backgroundColor={myColor.primary.lightGray} />
       <CenterContent>
         <TopNavBar backgroundColor={backgroundColor} />
-        <CreateAccountbookFormBox backgroundColor={backgroundColor} />
+        <CreateAccountbookFormBox
+          buttonEvent={createButtonClick}
+          backgroundColor={backgroundColor}
+        />
         <CreateAccountbookSetting
           labelColor="blue"
           links={[


### PR DESCRIPTION
### 📕 Issue Number

Linked #65 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 가계부 생성 페이지 입력 박스 수정
![image](https://user-images.githubusercontent.com/61405355/101528828-21a0c880-39d3-11eb-8b15-1847e3f709e4.png)
   - 이름 입력 부분을 TextArea atom을 이용하여 가계부 이름을 입력할 수 있도록 수정

<br/>

- TextArea atom 수정
![image](https://user-images.githubusercontent.com/61405355/101529015-53b22a80-39d3-11eb-85bd-c8745d743ec7.png)
   - 배경색, fontSize, fontColor를 조절할 수 있도록 수정
   - 입력한 내용을 가져올 수 있도록 onChange 이벤트 함수 등록

<br/>


- 입력한 내용을 가져올 수 있도록 formBox에서 useState로 값을 가질 수 있도록 설정
   - page단에서 입력하는 내용을 useState로 가지고 props로 넘겨주게 되면, 입력 내용이 계속 변하면서 페이지가 계속 rerendering 되기 때문에 page단에서 버튼 이벤트 함수를 넘겨 파라미터로 값을 가져올 수 있도록 구현

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 리펙토링

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- store를 따로 구현하지 않고 입력 값을 사용할 수 있도록 구현해보았습니다. rerendering을 하지 않도록 하위 컴포넌트에서 state를 유지하도록 구현하였습니다.


<br/><br/>