### PR TITLE
BE-feat-createAccountButton 가계부 생성 api 개발

### DIFF
--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -18,7 +18,6 @@ export const GET_EXPENDITURE_CATEGORY = `${process.env.REACT_APP_BASE_URL}/api/c
 
 export const GET_PAYMENT = `${process.env.REACT_APP_BASE_URL}/api/payment`;
 
-export const POST_CREATE_SOCIAL = `${process.env.REACT_APP_BASE_URL}/api/social/create`;
+export const POST_CREATE_SOCIAL = `${process.env.REACT_APP_BASE_URL}/api/social/createAccountbook`;
 
 export const GET_SOCIAL_FOUR_MONTH_STATISTICS = `${process.env.REACT_APP_BASE_URL}/api/social/statistics/monthly/`;
-

--- a/server/src/model/query/socialBookQuery.ts
+++ b/server/src/model/query/socialBookQuery.ts
@@ -57,6 +57,10 @@ const socialBookQuery = {
   READ_MONTHLY_STATISTICS_INCOME: `
   SELECT SUM(amount) FROM social_transaction 
   WHERE accountbook_id = ? AND date >= ? AND date < ? AND payment_id IS NULL`,
+  CREATE_SOCIAL_ACCOUNTBOOK:
+    'INSERT INTO social_accountbook (master_id, name, description, created_at, color) VALUES(?,?,?,?,?)',
+  CREATE_SOCIAL_ACCOUNTBOOK_USERS:
+    'INSERT INTO social_accountbook_users (user_id, accountbook_id, state, invited_at, accepted_at) VALUES(?,?,?,?,?)',
 };
 
 export default socialBookQuery;

--- a/server/src/model/query/socialBookQuery.ts
+++ b/server/src/model/query/socialBookQuery.ts
@@ -58,9 +58,9 @@ const socialBookQuery = {
   SELECT SUM(amount) FROM social_transaction 
   WHERE accountbook_id = ? AND date >= ? AND date < ? AND payment_id IS NULL`,
   CREATE_SOCIAL_ACCOUNTBOOK:
-    'INSERT INTO social_accountbook (master_id, name, description, created_at, color) VALUES(?,?,?,?,?)',
+    'INSERT INTO social_accountbook (master_id, name, description, color) VALUES(?,?,?,?)',
   CREATE_SOCIAL_ACCOUNTBOOK_USERS:
-    'INSERT INTO social_accountbook_users (user_id, accountbook_id, state, invited_at, accepted_at) VALUES(?,?,?,?,?)',
+    'INSERT INTO social_accountbook_users (user_id, accountbook_id, state) VALUES(?,?,?)',
 };
 
 export default socialBookQuery;

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -85,16 +85,9 @@ export const getPastFourMonthStatistics = async (ctx: any) => {
 export const createAccountbook = async (ctx: any) => {
   const { name, description, color } = ctx.request.body;
   const userId = ctx.userData.uid;
-  const now = new Date();
-  const AccountbookResult = await Service.createAccountbook(name, description, color, userId, now);
+  const AccountbookResult = await Service.createAccountbook(name, description, color, userId);
 
-  const AccountbookUserResult = await Service.createAccountbookUser(
-    userId,
-    AccountbookResult,
-    0,
-    now,
-    now,
-  );
+  const AccountbookUserResult = await Service.createAccountbookUser(userId, AccountbookResult, 0);
 
   const result = { AccountbookResult, AccountbookUserResult };
   response.success(ctx, result);
@@ -103,13 +96,7 @@ export const createAccountbook = async (ctx: any) => {
 export const createAccountbookUser = async (ctx: any) => {
   const { userId, accountbookId, state, invitedAt, acceptedAt } = ctx.request.body;
 
-  const result = await Service.createAccountbookUser(
-    userId,
-    accountbookId,
-    state,
-    invitedAt,
-    acceptedAt,
-  );
+  const result = await Service.createAccountbookUser(userId, accountbookId, state);
 
   response.success(ctx, result);
 };

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -43,7 +43,6 @@ export const createTransaction = async (ctx: any) => {
   response.success(ctx, result);
 };
 
-
 export const getCategoryStatistic = async (ctx: any) => {
   const { bookId, year, month } = ctx.params;
   const userId = ctx.userData.uid;
@@ -79,6 +78,38 @@ export const getPastFourMonthStatistics = async (ctx: any) => {
 
     result.push([Number(income), Number(expend)]);
   }
+
+  response.success(ctx, result);
+};
+
+export const createAccountbook = async (ctx: any) => {
+  const { name, description, color } = ctx.request.body;
+  const userId = ctx.userData.uid;
+  const now = new Date();
+  const AccountbookResult = await Service.createAccountbook(name, description, color, userId, now);
+
+  const AccountbookUserResult = await Service.createAccountbookUser(
+    userId,
+    AccountbookResult,
+    0,
+    now,
+    now,
+  );
+
+  const result = { AccountbookResult, AccountbookUserResult };
+  response.success(ctx, result);
+};
+
+export const createAccountbookUser = async (ctx: any) => {
+  const { userId, accountbookId, state, invitedAt, acceptedAt } = ctx.request.body;
+
+  const result = await Service.createAccountbookUser(
+    userId,
+    accountbookId,
+    state,
+    invitedAt,
+    acceptedAt,
+  );
 
   response.success(ctx, result);
 };

--- a/server/src/socialBook/router.ts
+++ b/server/src/socialBook/router.ts
@@ -16,5 +16,6 @@ router.get('/statistic/category/:bookId/:year/:month', Controller.getCategorySta
 
 router.get('/statistics/monthly/:bookId', Controller.getPastFourMonthStatistics);
 
+router.post('/createAccountbook', Controller.createAccountbook);
 
 export default router;

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -52,7 +52,6 @@ export const createTransaction = async (transaction: (string | number)[]) => {
   return result.insertId;
 };
 
-
 export const getIncomeCategory = async (bookId: number, year: number, month: number) => {
   const result = await sql(query.READ_SOCIAL_INCOME_CATEGORY, [bookId, year, month]);
   const percentResult = getCategoryPercentData(result);
@@ -90,4 +89,40 @@ export const getMonthlyStatisticsIncome = async (
     endDate,
   ]);
   return result[0]['SUM(amount)'];
+};
+
+export const createAccountbook = async (
+  name: string,
+  description: string,
+  color: string,
+  userId: Number,
+  createdAt: Date,
+) => {
+  const accountbookResult = await sql(query.CREATE_SOCIAL_ACCOUNTBOOK, [
+    userId,
+    name,
+    description,
+    createdAt,
+    color,
+  ]);
+
+  return accountbookResult.insertId;
+};
+
+export const createAccountbookUser = async (
+  userId: Number,
+  accountbookId: Number,
+  state: Number,
+  invitedAt: Date,
+  acceptedAt: Date,
+) => {
+  const accountbookUserResult = await sql(query.CREATE_SOCIAL_ACCOUNTBOOK_USERS, [
+    userId,
+    accountbookId,
+    state,
+    invitedAt,
+    acceptedAt,
+  ]);
+
+  return accountbookUserResult.insertId;
 };

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -96,13 +96,11 @@ export const createAccountbook = async (
   description: string,
   color: string,
   userId: Number,
-  createdAt: Date,
 ) => {
   const accountbookResult = await sql(query.CREATE_SOCIAL_ACCOUNTBOOK, [
     userId,
     name,
     description,
-    createdAt,
     color,
   ]);
 
@@ -113,15 +111,11 @@ export const createAccountbookUser = async (
   userId: Number,
   accountbookId: Number,
   state: Number,
-  invitedAt: Date,
-  acceptedAt: Date,
 ) => {
   const accountbookUserResult = await sql(query.CREATE_SOCIAL_ACCOUNTBOOK_USERS, [
     userId,
     accountbookId,
     state,
-    invitedAt,
-    acceptedAt,
   ]);
 
   return accountbookUserResult.insertId;


### PR DESCRIPTION
### 📕 Issue Number

Linked #65 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 가계부 생성 api 구현
![image](https://user-images.githubusercontent.com/61405355/101611217-96fcaf80-3a4c-11eb-9f36-0b615f5b6502.png)

- 가계부-사용자 테이블 create controller, service 구현
   - social 가계부 생성 시 state 0으로 social-accountbook-users에 추가해주어야 함. 따라서 createAccountbookUser를 추가적으로 만들어서 생성시에 해당 서비스도 함께 호출하여 사용하였음. 나중에 social-accountbook-users 테이블을 수정할 때 사용할 수 있도록 가계부 생성과 분리해서 구현해놓았음.

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 리펙토링

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- social-accountbook-users 테이블에 데이터를 추가하는 controller, service를 구현해두었습니다. 나중에 활용하시면 좋을 것 같습니다. 

<br/><br/>