### PR TITLE
BE-feat-socialTransactionList 소셜 가계부 연,월 조회 API 구현

### DIFF
--- a/server/src/model/query/socialBookQuery.ts
+++ b/server/src/model/query/socialBookQuery.ts
@@ -61,6 +61,12 @@ const socialBookQuery = {
     'INSERT INTO social_accountbook (master_id, name, description, color) VALUES(?,?,?,?)',
   CREATE_SOCIAL_ACCOUNTBOOK_USERS:
     'INSERT INTO social_accountbook_users (user_id, accountbook_id, state) VALUES(?,?,?)',
+  GET_SOCIAL_TRANSACTIONLIST: `
+    SELECT st.id, st.date, py.name, ct.name as category, st.title, st.amount, at.name as assortment FROM social_transaction as st 
+    JOIN category as ct ON st.category_id = ct.id 
+    JOIN assortment as at ON ct.assortment_id = at.id 
+    LEFT OUTER JOIN payment as py ON py.id = st.payment_id 
+    WHERE st.accountbook_id = ? AND year(st.date) = ? AND month(st.date) = ? ORDER BY st.date`,
 };
 
 export default socialBookQuery;

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -94,7 +94,7 @@ export const createAccountbook = async (ctx: any) => {
 };
 
 export const createAccountbookUser = async (ctx: any) => {
-  const { userId, accountbookId, state, invitedAt, acceptedAt } = ctx.request.body;
+  const { userId, accountbookId, state } = ctx.request.body;
 
   const result = await Service.createAccountbookUser(userId, accountbookId, state);
 

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -5,6 +5,7 @@ import message from '../utils/message';
 import 'dotenv/config';
 import * as Service from './service';
 import { getPastMonthList } from '../utils/date';
+import { TransactionList } from '../interface/transaction';
 
 export const getSocialBooks = async (ctx: Context) => {
   const userId = ctx.userData.uid;
@@ -98,5 +99,34 @@ export const createAccountbookUser = async (ctx: any) => {
 
   const result = await Service.createAccountbookUser(userId, accountbookId, state);
 
+  response.success(ctx, result);
+};
+
+export const getTransactionList = async (ctx: any) => {
+  const { accountbookId, year, month } = ctx.params;
+  const userId = ctx.userData.uid;
+
+  const bookIdList = await Service.getBelongSocialBookList(userId);
+
+  if (!bookIdList.includes(Number(accountbookId))) {
+    response.fail(ctx, 403, message.NO_SOCIAL_AUTHORIZED);
+    return;
+  }
+
+  const searchInfo = [accountbookId, year, month];
+  let result = await Service.getTransactionList(searchInfo);
+  result = result.map((eachData: TransactionList) => {
+    const inmoney = eachData.assortment === '수입' ? eachData.amount : 0;
+    const exmoney = eachData.assortment === '지출' ? eachData.amount : 0;
+    return {
+      id: eachData.id,
+      date: eachData.date,
+      inmoney,
+      exmoney,
+      payment: eachData.name,
+      category: eachData.category,
+      title: eachData.title,
+    };
+  });
   response.success(ctx, result);
 };

--- a/server/src/socialBook/router.ts
+++ b/server/src/socialBook/router.ts
@@ -10,6 +10,8 @@ router.get('/list/master', Controller.getSocialBooksMaster);
 
 router.get('/transaction/:bookId/:date', Controller.getDailyTransaction);
 
+router.get('/transaction/list/:accountbookId/:year/:month', Controller.getTransactionList);
+
 router.post('/transaction', Controller.createTransaction);
 
 router.get('/statistic/category/:bookId/:year/:month', Controller.getCategoryStatistic);

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -120,3 +120,7 @@ export const createAccountbookUser = async (
 
   return accountbookUserResult.insertId;
 };
+export const getTransactionList = async (searchInfo: (string | number)[]) => {
+  const result = await sql(query.GET_SOCIAL_TRANSACTIONLIST, searchInfo);
+  return result;
+};


### PR DESCRIPTION
### 📕 Issue Number

Close #63 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 소셜 가계부 내역 조회 API
![image](https://user-images.githubusercontent.com/61405355/101660924-0abdad00-3a8b-11eb-8b5d-32c2e28841cd.png)


- 소셜 가계부 createAccountbookUser controller, service에서 불필요한 변수 삭제

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 리펙토링

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- accountbookId를 넘겨 해당 가계부에 대해 현재 사용자가 권한이 있는지 확인하고 조회하도록 하였습니다.

<br/><br/>