### PR TITLE
FE-feat-transactionadd 거래내역 추가 기능 구현

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -25,6 +25,7 @@
     "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx", ".ts", ".tsx"] }],
     "no-unused-vars": "warn",
     "no-console": "off",
+    "no-alert": "off",
     "@typescript-eslint/no-unused-vars": ["error"],
     "no-use-before-define": "off",
     "@typescript-eslint/no-use-before-define": ["error"],

--- a/client/src/components/atoms/button/IconDetailButton/IconDetailButton.tsx
+++ b/client/src/components/atoms/button/IconDetailButton/IconDetailButton.tsx
@@ -64,7 +64,7 @@ const iconDetailButton: React.FC<Props> = ({ color, name, onClick }: Props) => {
   };
 
   return (
-    <Button onClick={onClick} color={color}>
+    <Button type="button" onClick={onClick} color={color}>
       {selectIcon(name)}
       <RowFlexContainer>
         <ButtonName>{name}</ButtonName>

--- a/client/src/components/atoms/button/RoundLongButton/RoundLongButton.tsx
+++ b/client/src/components/atoms/button/RoundLongButton/RoundLongButton.tsx
@@ -5,12 +5,14 @@ import myColor from '@theme/color';
 interface Props {
   backgroundColor?: string;
   color?: string;
+  isSubmit?: boolean;
   children: React.ReactChild;
   onClick?: () => void;
 }
 
 const defaultProps = {
   backgroundColor: myColor.primary.accent,
+  isSubmit: false,
   color: 'white',
   onClick: undefined,
 };
@@ -26,9 +28,20 @@ const Button = styled.button<Props>`
   color: ${(props) => props.color};
 `;
 
-const RoundLongButton: React.FC<Props> = ({ backgroundColor, color, children, onClick }: Props) => {
+const RoundLongButton: React.FC<Props> = ({
+  backgroundColor,
+  color,
+  isSubmit,
+  children,
+  onClick,
+}: Props) => {
   return (
-    <Button onClick={onClick} backgroundColor={backgroundColor} color={color}>
+    <Button
+      type={isSubmit ? 'submit' : 'button'}
+      onClick={onClick}
+      backgroundColor={backgroundColor}
+      color={color}
+    >
       {children}
     </Button>
   );

--- a/client/src/components/atoms/button/RoundShortButton/RoundShortButton.tsx
+++ b/client/src/components/atoms/button/RoundShortButton/RoundShortButton.tsx
@@ -7,6 +7,7 @@ interface Props {
   color?: string;
   children: React.ReactChild;
   border?: string;
+  isSubmit?: boolean;
   onClick?: () => void;
 }
 
@@ -14,6 +15,7 @@ const defaultProps = {
   backgroundColor: myColor.primary.accent,
   color: 'white',
   border: 'solid 1px',
+  isSubmit: false,
   onClick: undefined,
 };
 
@@ -36,10 +38,17 @@ const RoundShortButton: React.FC<Props> = ({
   color,
   children,
   border,
+  isSubmit,
   onClick,
 }: Props) => {
   return (
-    <Button onClick={onClick} backgroundColor={backgroundColor} color={color} border={border}>
+    <Button
+      type={isSubmit ? 'submit' : 'button'}
+      onClick={onClick}
+      backgroundColor={backgroundColor}
+      color={color}
+      border={border}
+    >
       {children}
     </Button>
   );

--- a/client/src/components/atoms/button/TextButton/TextButton.tsx
+++ b/client/src/components/atoms/button/TextButton/TextButton.tsx
@@ -26,7 +26,7 @@ const Button = styled.button<Props>`
 
 const TextButton: React.FC<Props> = ({ color, children, onClick }: Props) => {
   return (
-    <Button onClick={onClick} color={color}>
+    <Button type="button" onClick={onClick} color={color}>
       {children}
     </Button>
   );

--- a/client/src/components/atoms/div/ToggleButton/ToggleButton.tsx
+++ b/client/src/components/atoms/div/ToggleButton/ToggleButton.tsx
@@ -8,7 +8,6 @@ interface Props extends sizeProps {
   rightCallback: React.Dispatch<React.SetStateAction<boolean>>;
   leftButtonName: string;
   rightButtonName: string;
-  onClick: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 }
 
 interface sizeProps {

--- a/client/src/components/atoms/graph/TwoBarGraph/TwoBarGraph.tsx
+++ b/client/src/components/atoms/graph/TwoBarGraph/TwoBarGraph.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import myColor from '@theme/color';
-import ntm from '@utils/numberToMoney';
+import { numberToMoney } from '@utils/number';
 
 interface Props {
   maxHeight: number;
@@ -101,12 +101,12 @@ const TwoBarGraph: React.FC<Props> = ({ maxHeight, income, expend }: Props) => {
     <RowFlexContainer width="100%" height="100%" alignItems="center" justifyContent="space-around">
       <WhiteBar>
         <IncomeBar height={(income / maxHeight) * 100}>
-          <div>{ntm.number2Money(income)}</div>
+          <div>{numberToMoney(income)}</div>
         </IncomeBar>
       </WhiteBar>
       <WhiteBar>
         <ExpendBar height={(expend / maxHeight) * 100}>
-          <div>{ntm.number2Money(expend)}</div>
+          <div>{numberToMoney(expend)}</div>
         </ExpendBar>
       </WhiteBar>
     </RowFlexContainer>

--- a/client/src/components/atoms/input/DropdownMenu/DropdownMenu.tsx
+++ b/client/src/components/atoms/input/DropdownMenu/DropdownMenu.tsx
@@ -9,6 +9,8 @@ interface OptionData {
 
 interface Props extends selectProps {
   options: OptionData[];
+  value?: any;
+  onChange?: any;
 }
 
 interface selectProps {
@@ -23,6 +25,8 @@ const defaultProps = {
   width: '8rem',
   height: '1.2rem',
   fontSize: '1rem',
+  value: undefined,
+  onChange: undefined,
 };
 
 const Select = styled.select<selectProps>`
@@ -54,11 +58,26 @@ const Option = styled.option`
 const getOptionList = (options: Array<OptionData>) =>
   options.map((value) => <Option value={value.id}>{value.name}</Option>);
 
-const DropdownMenu: React.FC<Props> = ({ width, height, fontSize, color, options }: Props) => {
+const DropdownMenu: React.FC<Props> = ({
+  width,
+  height,
+  fontSize,
+  color,
+  options,
+  value,
+  onChange,
+}: Props) => {
   const optionList = getOptionList(options);
 
   return (
-    <Select width={width} height={height} fontSize={fontSize} color={color}>
+    <Select
+      width={width}
+      height={height}
+      fontSize={fontSize}
+      color={color}
+      value={value}
+      onChange={onChange}
+    >
       <Option value="">선택안함</Option>
       {optionList}
     </Select>

--- a/client/src/components/atoms/input/Input/Input.tsx
+++ b/client/src/components/atoms/input/Input/Input.tsx
@@ -10,6 +10,7 @@ interface Props {
   fontSize?: string;
   textAlign?: string;
   placeholder?: string;
+  isRequired?: boolean;
   value?: any;
   onChange?: any;
 }
@@ -22,6 +23,7 @@ const defaultProps = {
   fontSize: '1rem',
   textAlign: '',
   placeholder: '',
+  isRequired: true,
   value: undefined,
   onChange: undefined,
 };
@@ -57,6 +59,7 @@ const input: React.FC<Props> = ({
   fontSize,
   color,
   textAlign,
+  isRequired,
   value,
   onChange,
 }: Props) => {
@@ -71,6 +74,7 @@ const input: React.FC<Props> = ({
       color={color}
       value={value}
       onChange={onChange}
+      required={isRequired}
     />
   );
 };

--- a/client/src/components/atoms/input/Input/Input.tsx
+++ b/client/src/components/atoms/input/Input/Input.tsx
@@ -10,6 +10,8 @@ interface Props {
   fontSize?: string;
   textAlign?: string;
   placeholder?: string;
+  value?: any;
+  onChange?: any;
 }
 
 const defaultProps = {
@@ -20,6 +22,8 @@ const defaultProps = {
   fontSize: '1rem',
   textAlign: '',
   placeholder: '',
+  value: undefined,
+  onChange: undefined,
 };
 
 const Input = styled.input<Props>`
@@ -45,7 +49,7 @@ const Input = styled.input<Props>`
   }
 `;
 
-const RoundShortChips: React.FC<Props> = ({
+const input: React.FC<Props> = ({
   type,
   placeholder,
   width,
@@ -53,6 +57,8 @@ const RoundShortChips: React.FC<Props> = ({
   fontSize,
   color,
   textAlign,
+  value,
+  onChange,
 }: Props) => {
   return (
     <Input
@@ -63,10 +69,12 @@ const RoundShortChips: React.FC<Props> = ({
       fontSize={fontSize}
       textAlign={textAlign}
       color={color}
+      value={value}
+      onChange={onChange}
     />
   );
 };
 
-RoundShortChips.defaultProps = defaultProps;
+input.defaultProps = defaultProps;
 
-export default RoundShortChips;
+export default input;

--- a/client/src/components/atoms/p/ExpenditureText/ExpenditureText.tsx
+++ b/client/src/components/atoms/p/ExpenditureText/ExpenditureText.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import nTm from '@utils/numberToMoney';
+import { numberToMoney } from '@utils/number';
 import MyColor from '@theme/color';
 
 interface Props extends FontProps {
@@ -24,7 +24,7 @@ const ExpenditureText = styled.p<FontProps>`
 `;
 
 const expenditureText: React.FC<Props> = ({ fontWeight, fontSize, color, money }: Props) => {
-  const expenditureMoney = nTm.number2Money(money);
+  const expenditureMoney = numberToMoney(money);
   return (
     <ExpenditureText fontWeight={fontWeight} fontSize={fontSize} color={color}>
       {money === 0 ? <br /> : <>- {expenditureMoney}</>}

--- a/client/src/components/atoms/p/IncomeText/IncomeText.tsx
+++ b/client/src/components/atoms/p/IncomeText/IncomeText.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import nTm from '@utils/numberToMoney';
+import { numberToMoney } from '@utils/number';
 import MyColor from '@theme/color';
 
 interface Props extends FontProps {
@@ -24,7 +24,7 @@ const IncomeText = styled.p<FontProps>`
 `;
 
 const incomeText: React.FC<Props> = ({ fontWeight, fontSize, color, money }: Props) => {
-  const incomeMoney = nTm.number2Money(money);
+  const incomeMoney = numberToMoney(money);
   return (
     <IncomeText fontWeight={fontWeight} fontSize={fontSize} color={color}>
       {money === 0 ? <br /> : <>+ {incomeMoney}</>}

--- a/client/src/components/atoms/p/NumberText/NumberText.tsx
+++ b/client/src/components/atoms/p/NumberText/NumberText.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import nTm from '@utils/numberToMoney';
+import { numberToMoney } from '@utils/number';
 
 interface Props extends FontProps {
   money: number;
@@ -19,7 +19,7 @@ const NumberText = styled.p<FontProps>`
 `;
 
 const numberText: React.FC<Props> = ({ fontWeight, fontSize, color, money }: Props) => {
-  const numberMoney = nTm.number2Money(money);
+  const numberMoney = numberToMoney(money);
   return (
     <NumberText fontWeight={fontWeight} fontSize={fontSize} color={color}>
       {numberMoney}

--- a/client/src/components/molecules/DateWithText/DateWithText.stories.tsx
+++ b/client/src/components/molecules/DateWithText/DateWithText.stories.tsx
@@ -7,7 +7,10 @@ export default {
 };
 
 export const dateWithText = (): JSX.Element => {
-  return <DateWithText type="time" title="시간" />;
+  const onChange = () => {
+    return true;
+  };
+  return <DateWithText type="time" title="시간" value="" onChange={onChange} />;
 };
 
 dateWithText.story = {

--- a/client/src/components/molecules/DateWithText/DateWithText.tsx
+++ b/client/src/components/molecules/DateWithText/DateWithText.tsx
@@ -10,6 +10,8 @@ interface Props {
   width?: string;
   margin?: string;
   justifyContent?: string;
+  value: any;
+  onChange: any;
 }
 
 const defaultProps = {
@@ -22,13 +24,28 @@ const Container = styled.div`
   margin-right: 10px;
 `;
 
-const dateWithText: React.FC<Props> = ({ width, title, margin, justifyContent, type }: Props) => {
+const dateWithText: React.FC<Props> = ({
+  value,
+  onChange,
+  width,
+  title,
+  margin,
+  justifyContent,
+  type,
+}: Props) => {
   return (
     <DateWithText width={width} margin={margin} justifyContent={justifyContent}>
       <Container>
         <Text>{title}</Text>
       </Container>
-      <Input type={type} width="70%" textAlign="center" placeholder="00:00" />
+      <Input
+        value={value}
+        onChange={onChange}
+        type={type}
+        width="70%"
+        textAlign="center"
+        placeholder="00:00"
+      />
     </DateWithText>
   );
 };

--- a/client/src/components/molecules/InputWithText/InputWithText.stories.tsx
+++ b/client/src/components/molecules/InputWithText/InputWithText.stories.tsx
@@ -7,7 +7,10 @@ export default {
 };
 
 export const inputWithText = (): JSX.Element => {
-  return <InputWithText title="금액" />;
+  const onChange = () => {
+    return true;
+  };
+  return <InputWithText title="금액" value="" onChange={onChange} />;
 };
 
 inputWithText.story = {

--- a/client/src/components/molecules/InputWithText/InputWithText.tsx
+++ b/client/src/components/molecules/InputWithText/InputWithText.tsx
@@ -5,6 +5,8 @@ import Text from '@atoms/p/LeftLargeText';
 
 interface Props extends sizeProps {
   title: string;
+  value: any;
+  onChange: any;
 }
 
 interface sizeProps {
@@ -21,11 +23,18 @@ const InputWithText = styled.div<sizeProps>`
   width: ${(props) => props.width};
 `;
 
-const inputWithText: React.FC<Props> = ({ width, title }: Props) => {
+const inputWithText: React.FC<Props> = ({ width, title, value, onChange }: Props) => {
   return (
     <InputWithText width={width}>
       <Text>{title}</Text>
-      <Input width="85%" fontSize="1.4rem" textAlign="right" placeholder="0" />
+      <Input
+        width="85%"
+        fontSize="1.4rem"
+        textAlign="right"
+        placeholder="0"
+        value={value}
+        onChange={onChange}
+      />
       <Text>원</Text>
     </InputWithText>
   );

--- a/client/src/components/molecules/MenuWithText/MenuWithText.tsx
+++ b/client/src/components/molecules/MenuWithText/MenuWithText.tsx
@@ -11,6 +11,8 @@ interface OptionData {
 interface Props extends sizeProps {
   options: OptionData[];
   title: string;
+  value?: any;
+  onChange?: any;
 }
 
 interface sizeProps {
@@ -19,6 +21,8 @@ interface sizeProps {
 
 const defaultProps = {
   width: '15%',
+  value: undefined,
+  onChange: undefined,
 };
 
 const MenuWithText = styled.div<sizeProps>`
@@ -27,11 +31,11 @@ const MenuWithText = styled.div<sizeProps>`
   width: ${(props) => props.width};
 `;
 
-const menuWithText: React.FC<Props> = ({ width, title, options }: Props) => {
+const menuWithText: React.FC<Props> = ({ width, title, options, value, onChange }: Props) => {
   return (
     <MenuWithText width={width}>
       <Text>{title}</Text>
-      <DropdownMenu width="70%" options={options} />
+      <DropdownMenu width="70%" options={options} value={value} onChange={onChange} />
     </MenuWithText>
   );
 };

--- a/client/src/components/molecules/TwoByTwoChips/TwoByTwoChips.tsx
+++ b/client/src/components/molecules/TwoByTwoChips/TwoByTwoChips.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import myColor from '@theme/color';
 import styled from 'styled-components';
-import ntm from '@utils/numberToMoney';
+import { numberToMoney } from '@utils/number';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import SquircleShortChips from '@atoms/div/SquircleShortChips';
 
@@ -21,22 +21,22 @@ const TwoByTwoChips: React.FC<props> = ({ categoryList, amountList }: props) => 
     <RowFlexContainer width="100%" height="100%" flexWrap="wrap">
       <ChipsContainer>
         <SquircleShortChips width="100%" backgroundColor={myColor.primary.white}>
-          {`${categoryList[0]} ${ntm.number2Money(amountList[0])}`}
+          {`${categoryList[0]} ${numberToMoney(amountList[0])}`}
         </SquircleShortChips>
       </ChipsContainer>
       <ChipsContainer>
         <SquircleShortChips width="100%" backgroundColor={myColor.primary.white}>
-          {`${categoryList[1]} ${ntm.number2Money(amountList[1])}`}
+          {`${categoryList[1]} ${numberToMoney(amountList[1])}`}
         </SquircleShortChips>
       </ChipsContainer>
       <ChipsContainer>
         <SquircleShortChips width="100%" backgroundColor={myColor.primary.white}>
-          {`${categoryList[2]} ${ntm.number2Money(amountList[2])}`}
+          {`${categoryList[2]} ${numberToMoney(amountList[2])}`}
         </SquircleShortChips>
       </ChipsContainer>
       <ChipsContainer>
         <SquircleShortChips width="100%" backgroundColor={myColor.primary.white}>
-          {`${categoryList[3]} ${ntm.number2Money(amountList[3])}`}
+          {`${categoryList[3]} ${numberToMoney(amountList[3])}`}
         </SquircleShortChips>
       </ChipsContainer>
     </RowFlexContainer>

--- a/client/src/components/organisms/CreateTransactionMenu/CreateTransactionMenu.stories.tsx
+++ b/client/src/components/organisms/CreateTransactionMenu/CreateTransactionMenu.stories.tsx
@@ -10,7 +10,7 @@ export const createTransactionMenu = (): JSX.Element => {
   const onClick = () => {
     return true;
   };
-  return <CreateTransactionMenu submit={onClick} cancel={onClick} />;
+  return <CreateTransactionMenu cancel={onClick} />;
 };
 
 createTransactionMenu.story = {

--- a/client/src/components/organisms/CreateTransactionMenu/CreateTransactionMenu.tsx
+++ b/client/src/components/organisms/CreateTransactionMenu/CreateTransactionMenu.tsx
@@ -20,7 +20,9 @@ const BottomDiv = styled.div`
 const createTransactionMenu: React.FC<Props> = ({ submit, cancel }: Props) => {
   return (
     <BottomDiv>
-      <RoundLongButton onClick={submit}>등록</RoundLongButton>
+      <RoundLongButton isSubmit onClick={submit}>
+        등록
+      </RoundLongButton>
       <RoundLongButton onClick={cancel} backgroundColor={myColor.primary.cancel}>
         취소
       </RoundLongButton>

--- a/client/src/components/organisms/CreateTransactionMenu/CreateTransactionMenu.tsx
+++ b/client/src/components/organisms/CreateTransactionMenu/CreateTransactionMenu.tsx
@@ -4,7 +4,6 @@ import RoundLongButton from '@atoms/button/RoundLongButton';
 import myColor from '@theme/color';
 
 interface Props {
-  submit: () => void;
   cancel: () => void;
 }
 
@@ -17,12 +16,10 @@ const BottomDiv = styled.div`
   margin: 0px -20px;
 `;
 
-const createTransactionMenu: React.FC<Props> = ({ submit, cancel }: Props) => {
+const createTransactionMenu: React.FC<Props> = ({ cancel }: Props) => {
   return (
     <BottomDiv>
-      <RoundLongButton isSubmit onClick={submit}>
-        등록
-      </RoundLongButton>
+      <RoundLongButton isSubmit>등록</RoundLongButton>
       <RoundLongButton onClick={cancel} backgroundColor={myColor.primary.cancel}>
         취소
       </RoundLongButton>

--- a/client/src/components/organisms/FourMonthStatistics/FourMonthStatistics.tsx
+++ b/client/src/components/organisms/FourMonthStatistics/FourMonthStatistics.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { getPastMonthList } from '@utils/calcMonth';
-import ntm from '@utils/numberToMoney';
+import { numberToMoney } from '@utils/number';
 import getRandomKey from '@utils/random';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import TwoBarGraph from '@atoms/graph/TwoBarGraph';
@@ -86,8 +86,8 @@ const FourMonthStatistics: React.FC<props> = ({ data }: props) => {
       <RowFlexContainer width="100%" height="20%" alignItems="flex-start">
         <InfoBox>
           <p>{`${monthList[monthIndex]}월`}</p>
-          <p>{data.length !== 0 ? `수입 : ${ntm.number2Money(data[monthIndex][income])}` : ''}</p>
-          <p>{data.length !== 0 ? `지출 : ${ntm.number2Money(data[monthIndex][expend])}` : ''}</p>
+          <p>{data.length !== 0 ? `수입 : ${numberToMoney(data[monthIndex][income])}` : ''}</p>
+          <p>{data.length !== 0 ? `지출 : ${numberToMoney(data[monthIndex][expend])}` : ''}</p>
         </InfoBox>
       </RowFlexContainer>
       <RowFlexContainer width="100%" height="60%">

--- a/client/src/components/organisms/TransactionForm/TransactionForm.stories.tsx
+++ b/client/src/components/organisms/TransactionForm/TransactionForm.stories.tsx
@@ -7,10 +7,7 @@ export default {
 };
 
 export const transactionForm = (): JSX.Element => {
-  const onClick = () => {
-    return true;
-  };
-  return <TransactionForm onClick={onClick} />;
+  return <TransactionForm />;
 };
 
 transactionForm.story = {

--- a/client/src/components/organisms/TransactionForm/TransactionForm.tsx
+++ b/client/src/components/organisms/TransactionForm/TransactionForm.tsx
@@ -8,6 +8,7 @@ import DateWithText from '@molecules/DateWithText';
 import MenuWithText from '@molecules/MenuWithText';
 import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
+import { inputToNumber, numberToMoney } from '@utils/number';
 import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
 
@@ -38,7 +39,8 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
   const [isIncome, setIsIncome] = useState(true);
   const [isExpenditure, setIsExpenditure] = useState(false);
 
-  const [title, setTitle] = useState('');
+  const [title, setTitle] = useState<string>();
+  const [amount, setAmount] = useState<string>();
 
   const titleInputChange = (e) => {
     const input = e.target.value;
@@ -47,6 +49,12 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
       return;
     }
     setTitle(input);
+  };
+
+  const amountInputChange = (e) => {
+    const input = inputToNumber(e.target.value);
+    const money = numberToMoney(input);
+    setAmount(money);
   };
 
   return (
@@ -66,14 +74,14 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
       <InputContainer>
         <InputDiv>
           <Input
-            value={title}
             fontSize="1.4rem"
             placeholder="최대 15자까지 입력가능합니다"
             width="100%"
+            value={title}
             onChange={titleInputChange}
           />
         </InputDiv>
-        <InputWithText title="금액" width="100%" />
+        <InputWithText title="금액" width="100%" value={amount} onChange={amountInputChange} />
         <RowFlexContainer justifyContent="space-between">
           <DateWithText type="date" title="날짜" width="55%" />
           <DateWithText type="time" title="시간" width="45%" justifyContent="flex-end" />

--- a/client/src/components/organisms/TransactionForm/TransactionForm.tsx
+++ b/client/src/components/organisms/TransactionForm/TransactionForm.tsx
@@ -38,6 +38,17 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
   const [isIncome, setIsIncome] = useState(true);
   const [isExpenditure, setIsExpenditure] = useState(false);
 
+  const [title, setTitle] = useState('');
+
+  const titleInputChange = (e) => {
+    const input = e.target.value;
+    if (input.length > 15) {
+      alert('내용은 최대 15자까지만 입력 가능합니다!');
+      return;
+    }
+    setTitle(input);
+  };
+
   return (
     <ColumnFlexContainer width="100%" justifyContent="space-around">
       <RowFlexContainer width="100%" alignItems="center">
@@ -54,7 +65,13 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
       </RowFlexContainer>
       <InputContainer>
         <InputDiv>
-          <Input fontSize="1.4rem" placeholder="최대 15자까지 입력가능합니다" width="100%" />
+          <Input
+            value={title}
+            fontSize="1.4rem"
+            placeholder="최대 15자까지 입력가능합니다"
+            width="100%"
+            onChange={titleInputChange}
+          />
         </InputDiv>
         <InputWithText title="금액" width="100%" />
         <RowFlexContainer justifyContent="space-between">

--- a/client/src/components/organisms/TransactionForm/TransactionForm.tsx
+++ b/client/src/components/organisms/TransactionForm/TransactionForm.tsx
@@ -43,8 +43,8 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
   const [amount, setAmount] = useState<string>();
   const [date, setDate] = useState<string>();
   const [time, setTime] = useState<string>();
-  const [categoryId, setCategoryId] = useState<number>();
-  const [paymentId, setPaymentId] = useState<number>();
+  const [categoryId, setCategoryId] = useState<number | string>();
+  const [paymentId, setPaymentId] = useState<number | string>();
 
   const titleInputChange = (e) => {
     const input = e.target.value;
@@ -66,6 +66,15 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
     callback(input);
   };
 
+  const clearInput = () => {
+    setTitle('');
+    setAmount('');
+    setDate('');
+    setTime('');
+    setCategoryId('');
+    setPaymentId('');
+  };
+
   return (
     <ColumnFlexContainer width="100%" justifyContent="space-around">
       <RowFlexContainer width="100%" alignItems="center">
@@ -77,7 +86,7 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
           onClick={onClick}
         />
         <DeleteButtonContainer>
-          <TextButton>모두 지우기</TextButton>
+          <TextButton onClick={clearInput}>모두 지우기</TextButton>
         </DeleteButtonContainer>
       </RowFlexContainer>
       <InputContainer>

--- a/client/src/components/organisms/TransactionForm/TransactionForm.tsx
+++ b/client/src/components/organisms/TransactionForm/TransactionForm.tsx
@@ -41,6 +41,8 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
 
   const [title, setTitle] = useState<string>();
   const [amount, setAmount] = useState<string>();
+  const [date, setDate] = useState<string>();
+  const [time, setTime] = useState<string>();
 
   const titleInputChange = (e) => {
     const input = e.target.value;
@@ -55,6 +57,16 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
     const input = inputToNumber(e.target.value);
     const money = numberToMoney(input);
     setAmount(money);
+  };
+
+  const dateInputChange = (e) => {
+    const input = e.target.value;
+    setDate(input);
+  };
+
+  const timeInputChange = (e) => {
+    const input = e.target.value;
+    setTime(input);
   };
 
   return (
@@ -83,8 +95,21 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
         </InputDiv>
         <InputWithText title="금액" width="100%" value={amount} onChange={amountInputChange} />
         <RowFlexContainer justifyContent="space-between">
-          <DateWithText type="date" title="날짜" width="55%" />
-          <DateWithText type="time" title="시간" width="45%" justifyContent="flex-end" />
+          <DateWithText
+            type="date"
+            title="날짜"
+            width="55%"
+            value={date}
+            onChange={dateInputChange}
+          />
+          <DateWithText
+            type="time"
+            title="시간"
+            width="45%"
+            justifyContent="flex-end"
+            value={time}
+            onChange={timeInputChange}
+          />
         </RowFlexContainer>
         {isIncome && <MenuWithText options={income} title="카테고리" width="100%" />}
         {isExpenditure && <MenuWithText options={expenditure} title="카테고리" width="100%" />}

--- a/client/src/components/organisms/TransactionForm/TransactionForm.tsx
+++ b/client/src/components/organisms/TransactionForm/TransactionForm.tsx
@@ -16,7 +16,6 @@ import { postData } from '@interfaces/transaction';
 
 interface Props {
   initData?: postData | undefined;
-  onClick: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 }
 
 const defaultProps = {
@@ -38,7 +37,7 @@ const DeleteButtonContainer = styled.div`
 
 const InputDiv = styled.div``;
 
-const transactionForm: React.FC<Props> = ({ initData, onClick }: Props) => {
+const transactionForm: React.FC<Props> = ({ initData }: Props) => {
   const income = useSelector((state: RootState) => state.category.income);
   const expenditure = useSelector((state: RootState) => state.category.expenditure);
   const payment = useSelector((state: RootState) => state.payment.payment);
@@ -109,7 +108,6 @@ const transactionForm: React.FC<Props> = ({ initData, onClick }: Props) => {
           rightButtonName="지출"
           leftCallback={setIsIncome}
           rightCallback={setIsExpenditure}
-          onClick={onClick}
         />
         <DeleteButtonContainer>
           <TextButton onClick={clearInput}>모두 지우기</TextButton>

--- a/client/src/components/organisms/TransactionForm/TransactionForm.tsx
+++ b/client/src/components/organisms/TransactionForm/TransactionForm.tsx
@@ -43,6 +43,8 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
   const [amount, setAmount] = useState<string>();
   const [date, setDate] = useState<string>();
   const [time, setTime] = useState<string>();
+  const [categoryId, setCategoryId] = useState<number>();
+  const [paymentId, setPaymentId] = useState<number>();
 
   const titleInputChange = (e) => {
     const input = e.target.value;
@@ -59,14 +61,9 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
     setAmount(money);
   };
 
-  const dateInputChange = (e) => {
+  const inputChange = (e, callback) => {
     const input = e.target.value;
-    setDate(input);
-  };
-
-  const timeInputChange = (e) => {
-    const input = e.target.value;
-    setTime(input);
+    callback(input);
   };
 
   return (
@@ -100,7 +97,7 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
             title="날짜"
             width="55%"
             value={date}
-            onChange={dateInputChange}
+            onChange={(e) => inputChange(e, setDate)}
           />
           <DateWithText
             type="time"
@@ -108,12 +105,34 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
             width="45%"
             justifyContent="flex-end"
             value={time}
-            onChange={timeInputChange}
+            onChange={(e) => inputChange(e, setTime)}
           />
         </RowFlexContainer>
-        {isIncome && <MenuWithText options={income} title="카테고리" width="100%" />}
-        {isExpenditure && <MenuWithText options={expenditure} title="카테고리" width="100%" />}
-        <MenuWithText options={payment} title="결제수단" width="100%" />
+        {isIncome && (
+          <MenuWithText
+            options={income}
+            title="카테고리"
+            width="100%"
+            value={categoryId}
+            onChange={(e) => inputChange(e, setCategoryId)}
+          />
+        )}
+        {isExpenditure && (
+          <MenuWithText
+            options={expenditure}
+            title="카테고리"
+            width="100%"
+            value={categoryId}
+            onChange={(e) => inputChange(e, setCategoryId)}
+          />
+        )}
+        <MenuWithText
+          options={payment}
+          title="결제수단"
+          width="100%"
+          value={paymentId}
+          onChange={(e) => inputChange(e, setPaymentId)}
+        />
       </InputContainer>
     </ColumnFlexContainer>
   );

--- a/client/src/components/organisms/TransactionForm/TransactionForm.tsx
+++ b/client/src/components/organisms/TransactionForm/TransactionForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import ToggleButton from '@atoms/div/ToggleButton';
 import TextButton from '@atoms/button/TextButton';
@@ -9,12 +9,19 @@ import MenuWithText from '@molecules/MenuWithText';
 import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import { inputToNumber, numberToMoney } from '@utils/number';
+import { getDate, getTime } from '@utils/date';
 import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
+import { postData } from '@interfaces/transaction';
 
 interface Props {
+  initData?: postData | undefined;
   onClick: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 }
+
+const defaultProps = {
+  initData: undefined,
+};
 
 const InputContainer = styled.div`
   display: flex;
@@ -31,7 +38,7 @@ const DeleteButtonContainer = styled.div`
 
 const InputDiv = styled.div``;
 
-const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
+const transactionForm: React.FC<Props> = ({ initData, onClick }: Props) => {
   const income = useSelector((state: RootState) => state.category.income);
   const expenditure = useSelector((state: RootState) => state.category.expenditure);
   const payment = useSelector((state: RootState) => state.payment.payment);
@@ -74,6 +81,25 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
     setCategoryId('');
     setPaymentId('');
   };
+
+  useEffect(() => {
+    if (initData !== undefined) {
+      // TODO : 수입 지출에 따른 토글 버튼 변화
+      const initAmount = numberToMoney(initData.amount);
+      const initDate = getDate(initData.date);
+      const initTime = getTime(initData.date);
+      const initPayment = initData.paymentId;
+      console.log(initDate);
+      setTitle(initData.title);
+      setAmount(initAmount);
+      setDate(initDate);
+      setTime(initTime);
+      setCategoryId(initData.categoryId);
+      if (initPayment) {
+        setPaymentId(initPayment);
+      }
+    }
+  }, []);
 
   return (
     <ColumnFlexContainer width="100%" justifyContent="space-around">
@@ -146,5 +172,7 @@ const transactionForm: React.FC<Props> = ({ onClick }: Props) => {
     </ColumnFlexContainer>
   );
 };
+
+transactionForm.defaultProps = defaultProps;
 
 export default transactionForm;

--- a/client/src/components/organisms/TransactionForm/TransactionForm.tsx
+++ b/client/src/components/organisms/TransactionForm/TransactionForm.tsx
@@ -166,6 +166,7 @@ const transactionForm: React.FC<Props> = ({ initData }: Props) => {
           value={paymentId}
           onChange={(e) => inputChange(e, setPaymentId)}
         />
+        <input value={Number(isIncome)} hidden />
       </InputContainer>
     </ColumnFlexContainer>
   );

--- a/client/src/interfaces/transaction.ts
+++ b/client/src/interfaces/transaction.ts
@@ -1,0 +1,8 @@
+export interface postData {
+  isIncome: boolean;
+  title: string;
+  amount: number;
+  date: string;
+  categoryId: number;
+  paymentId: number | undefined;
+}

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -19,3 +19,7 @@ export const GET_EXPENDITURE_CATEGORY = `${process.env.REACT_APP_BASE_URL}/api/c
 export const GET_PAYMENT = `${process.env.REACT_APP_BASE_URL}/api/payment`;
 
 export const GET_SOCIAL_FOUR_MONTH_STATISTICS = `${process.env.REACT_APP_BASE_URL}/api/social/statistics/monthly/`;
+
+export const POST_PRIVATE_TRANSACTION = `${process.env.REACT_APP_BASE_URL}/api/private/transaction`;
+
+export const POST_SOCIAL_TRANSACTION = `${process.env.REACT_APP_BASE_URL}/api/social/transaction`;

--- a/client/src/utils/date.ts
+++ b/client/src/utils/date.ts
@@ -1,0 +1,22 @@
+const getNumberTwoDigits = (number: number): string => {
+  return number >= 10 ? `${number}` : `0${number}`;
+};
+
+export const getDate = (now: string): string => {
+  const date = new Date(now);
+  const year = date.getFullYear();
+  const month = 1 + date.getMonth();
+  const monthString = getNumberTwoDigits(month);
+  const day = date.getDate();
+  const dayString = getNumberTwoDigits(day);
+  return `${year}-${monthString}-${dayString}`;
+};
+
+export const getTime = (now: string): string => {
+  const date = new Date(now);
+  const hour = date.getHours();
+  const hourString = getNumberTwoDigits(hour);
+  const minute = date.getMinutes();
+  const minuteString = getNumberTwoDigits(minute);
+  return `${hourString}:${minuteString}`;
+};

--- a/client/src/utils/number.ts
+++ b/client/src/utils/number.ts
@@ -1,0 +1,5 @@
+export const numberToMoney = (money: number): string => {
+  return money.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+};
+
+export default numberToMoney;

--- a/client/src/utils/number.ts
+++ b/client/src/utils/number.ts
@@ -2,4 +2,7 @@ export const numberToMoney = (money: number): string => {
   return money.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 };
 
-export default numberToMoney;
+export const inputToNumber = (input: string): number => {
+  const number = Number(input.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1'));
+  return number;
+};

--- a/client/src/utils/numberToMoney.ts
+++ b/client/src/utils/numberToMoney.ts
@@ -1,5 +1,0 @@
-const number2Money = (money: number): string => {
-  return money.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-};
-
-export default { number2Money };

--- a/client/src/views/StatisticsPage.tsx
+++ b/client/src/views/StatisticsPage.tsx
@@ -35,10 +35,6 @@ const StatisticsPage: React.FC = () => {
     initFourMonthData();
   }, []);
 
-  const onClick = () => {
-    return true;
-  };
-
   return (
     <>
       <MonthNav />
@@ -47,7 +43,6 @@ const StatisticsPage: React.FC = () => {
         rightButtonName="지출"
         leftCallback={setIsIncome}
         rightCallback={setIsExpenditure}
-        onClick={onClick}
       />
       <ColumFlexContainer width="100%" alignItems="center">
         <FourMonthStatistics data={fourMonthData} />

--- a/client/src/views/TransactionEditPage.tsx
+++ b/client/src/views/TransactionEditPage.tsx
@@ -24,7 +24,7 @@ const TransactionPostPage: React.FC = () => {
       <CenterContent>
         <TopNavBar />
         <Container>
-          <TransactionForm onClick={onClick} />
+          <TransactionForm />
           <EditTransactionMenu submit={onClick} remove={onClick} cancel={cancel} />
         </Container>
       </CenterContent>

--- a/client/src/views/TransactionPostPage.tsx
+++ b/client/src/views/TransactionPostPage.tsx
@@ -7,6 +7,10 @@ import TransactionForm from '@organisms/TransactionForm';
 import CreateTransactionMenu from '@organisms/CreateTransactionMenu';
 import { inputToNumber } from '@utils/number';
 import { useHistory } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { RootState } from '@reducers/rootReducer';
+import { postAxios } from '@utils/axios';
+import * as API from '@utils/api';
 
 // eslint-disable-next-line no-shadow
 enum Form {
@@ -24,8 +28,25 @@ const Container = styled.div`
 `;
 
 const TransactionPostPage: React.FC = () => {
+  const accountbookType = useSelector((state: RootState) => state.accountbook.type);
+  const accountbookId = useSelector((state: RootState) => state.accountbook.socialId);
+
   const history = useHistory();
   const cancel = () => {
+    history.go(-1);
+  };
+
+  const postTransaction = async (data) => {
+    switch (accountbookType) {
+      case 'PRIVATE':
+        await postAxios(API.POST_PRIVATE_TRANSACTION, data);
+        break;
+      case 'SOCIAL':
+        await postAxios(API.POST_SOCIAL_TRANSACTION, data);
+        break;
+      default:
+        break;
+    }
     history.go(-1);
   };
 
@@ -35,11 +56,19 @@ const TransactionPostPage: React.FC = () => {
     const amount = inputToNumber(event.target[Form.Amount].value);
     const day = event.target[Form.Day].value;
     const time = `${event.target[Form.Time].value}:00`;
-    const date = day + time;
+    const date = `${day} ${time}`;
     const categoryId = event.target[Form.CategoryId].value;
-    const paymentId = event.target[Form.PaymentId].value;
     const isIncome = Boolean(Number(event.target[Form.IsIncome].value));
-    console.log(title, amount, date, categoryId, paymentId, isIncome);
+    const paymentId = isIncome ? undefined : event.target[Form.PaymentId].value;
+    const data = {
+      accountbookId,
+      title,
+      amount,
+      date,
+      categoryId,
+      paymentId,
+    };
+    postTransaction(data);
   };
 
   return (

--- a/client/src/views/TransactionPostPage.tsx
+++ b/client/src/views/TransactionPostPage.tsx
@@ -25,9 +25,11 @@ const TransactionPostPage: React.FC = () => {
       <CenterContent>
         <TopNavBar />
         <Container>
-          <CreateTransactionHeader />
-          <TransactionForm onClick={onClick} />
-          <CreateTransactionMenu submit={onClick} cancel={cancel} />
+          <form onSubmit={submitHandler}>
+            <CreateTransactionHeader />
+            <TransactionForm />
+            <CreateTransactionMenu cancel={cancel} />
+          </form>
         </Container>
       </CenterContent>
     </>

--- a/client/src/views/TransactionPostPage.tsx
+++ b/client/src/views/TransactionPostPage.tsx
@@ -5,7 +5,19 @@ import CenterContent from '@molecules/CenterContent';
 import CreateTransactionHeader from '@organisms/CreateTransactionHeader';
 import TransactionForm from '@organisms/TransactionForm';
 import CreateTransactionMenu from '@organisms/CreateTransactionMenu';
+import { inputToNumber } from '@utils/number';
 import { useHistory } from 'react-router-dom';
+
+// eslint-disable-next-line no-shadow
+enum Form {
+  Title = 5,
+  Amount = 6,
+  Day = 7,
+  Time = 8,
+  CategoryId = 9,
+  PaymentId = 10,
+  IsIncome = 11,
+}
 
 const Container = styled.div`
   margin: 40px 20px 0px;
@@ -16,8 +28,18 @@ const TransactionPostPage: React.FC = () => {
   const cancel = () => {
     history.go(-1);
   };
-  const onClick = () => {
-    return true;
+
+  const submitHandler = (event) => {
+    event.preventDefault();
+    const title = event.target[Form.Title].value;
+    const amount = inputToNumber(event.target[Form.Amount].value);
+    const day = event.target[Form.Day].value;
+    const time = `${event.target[Form.Time].value}:00`;
+    const date = day + time;
+    const categoryId = event.target[Form.CategoryId].value;
+    const paymentId = event.target[Form.PaymentId].value;
+    const isIncome = Boolean(Number(event.target[Form.IsIncome].value));
+    console.log(title, amount, date, categoryId, paymentId, isIncome);
   };
 
   return (

--- a/server/src/privateBook/controller.ts
+++ b/server/src/privateBook/controller.ts
@@ -4,7 +4,9 @@ import * as Service from './service';
 import { TransactionList } from '../interface/transaction';
 
 export const createTransaction = async (ctx: any) => {
-  const { accountbookId, categoryId, paymentId, date, title, amount } = ctx.request.body;
+  const userId = ctx.userData.uid;
+  const accountbookId = await Service.getAccountBookId(userId);
+  const { categoryId, paymentId, date, title, amount } = ctx.request.body;
   const transaction = [accountbookId, categoryId, paymentId, date, title, amount];
   const result = await Service.createTransaction(transaction);
   response.success(ctx, result);

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -37,12 +37,20 @@ export const getDailyTransaction = async (ctx: Context) => {
 };
 
 export const createTransaction = async (ctx: any) => {
-  const { accountbookId, userId, categoryId, paymentId, date, title, amount } = ctx.request.body;
+  const userId = ctx.userData.uid;
+  const { accountbookId, categoryId, paymentId, date, title, amount } = ctx.request.body;
+
+  const bookIdList = await Service.getBelongSocialBookList(userId);
+
+  if (!bookIdList.includes(Number(accountbookId))) {
+    response.fail(ctx, 403, message.NO_SOCIAL_AUTHORIZED);
+    return;
+  }
+
   const transaction = [accountbookId, userId, categoryId, paymentId, date, title, amount];
   const result = await Service.createTransaction(transaction);
   response.success(ctx, result);
 };
-
 
 export const getCategoryStatistic = async (ctx: any) => {
   const { bookId, year, month } = ctx.params;


### PR DESCRIPTION
### 📕 Issue Number

Close #58 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- transaction form 입력값 제어
    - 숫자만 입력받고 3단위로 , 찍기
    - input 값 무조건 입력해야 submit
    - title 글자수 제한 (최대 15자)
- transaction post 요청 api 보완
- 거래 내역 생성 버튼 백엔드 연동 
    - 소셜/개인 가계부 여부에 따라 처리를 다르게 해주었습니다.

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 버그 수정
- 리펙토링

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 작업하다보니 PR 크기가 많이 커졌네요 ㅠㅠ 죄송합니다! 다음부턴 더 잘게 나누어 작업하도록 하겠습니다😥
- 이전 페이지로 가는 부분이나 폼을 제출한 뒤 페이지 이동 등의 작업에서 개선이 필요할 것 같습니다.
- select tag는 선택하지 않은 것에 대한 예외처리를 아직 진행하지 못했습니다. 개선이 필요할 것 같습니다.
- useState와 form 을 이용하여 입력값 제어를 진행하였습니다.

<br/><br/>