### PR TITLE
FE-fix-week4-jjy 추가 수정

### DIFF
--- a/client/src/components/atoms/div/RowFlexContainer/RowFlexContainer.tsx
+++ b/client/src/components/atoms/div/RowFlexContainer/RowFlexContainer.tsx
@@ -15,6 +15,7 @@ interface Props {
   borderStyle?: string;
   position?: string;
   backgroundColor?: string;
+  zIndex?: string;
 }
 
 const defaultProps = {
@@ -31,11 +32,14 @@ const defaultProps = {
   padding: '0',
   position: 'static',
   backgroundColor: 'transparant',
+  zIndex: 'auto',
 };
 
 const Div = styled.div<Props>`
   display: flex;
   flex-direction: row;
+  max-width: 1195px;
+  z-index: ${(props) => props.zIndex};
   justify-content: ${(props) => props.justifyContent};
   align-content: ${(props) => props.alignContent};
   align-items: ${(props) => props.alignItems};

--- a/client/src/components/atoms/div/RowFlexContainer/RowFlexContainer.tsx
+++ b/client/src/components/atoms/div/RowFlexContainer/RowFlexContainer.tsx
@@ -14,6 +14,7 @@ interface Props {
   borderWidth?: string;
   borderStyle?: string;
   position?: string;
+  backgroundColor?: string;
 }
 
 const defaultProps = {
@@ -29,6 +30,7 @@ const defaultProps = {
   children: '',
   padding: '0',
   position: 'static',
+  backgroundColor: 'transparant',
 };
 
 const Div = styled.div<Props>`
@@ -45,6 +47,7 @@ const Div = styled.div<Props>`
   border-width: ${(props) => props.borderWidth};
   border-style: ${(props) => props.borderStyle};
   position: ${(props) => props.position};
+  background-color: ${(props) => props.backgroundColor};
 `;
 
 const RowFlexContainer: React.FC<Props> = ({ children, ...props }: Props) => {

--- a/client/src/components/atoms/p/ExpenditureText/ExpenditureText.tsx
+++ b/client/src/components/atoms/p/ExpenditureText/ExpenditureText.tsx
@@ -27,7 +27,7 @@ const expenditureText: React.FC<Props> = ({ fontWeight, fontSize, color, money }
   const expenditureMoney = numberToMoney(money);
   return (
     <ExpenditureText fontWeight={fontWeight} fontSize={fontSize} color={color}>
-      {money === 0 ? <br /> : <>- {expenditureMoney}</>}
+      {money === 0 ? <br /> : `-${expenditureMoney}`}
     </ExpenditureText>
   );
 };

--- a/client/src/components/atoms/p/IncomeText/IncomeText.tsx
+++ b/client/src/components/atoms/p/IncomeText/IncomeText.tsx
@@ -27,7 +27,7 @@ const incomeText: React.FC<Props> = ({ fontWeight, fontSize, color, money }: Pro
   const incomeMoney = numberToMoney(money);
   return (
     <IncomeText fontWeight={fontWeight} fontSize={fontSize} color={color}>
-      {money === 0 ? <br /> : <>+ {incomeMoney}</>}
+      {money === 0 ? <br /> : `+${incomeMoney}`}
     </IncomeText>
   );
 };

--- a/client/src/components/molecules/MonthNav/MonthNav.tsx
+++ b/client/src/components/molecules/MonthNav/MonthNav.tsx
@@ -26,7 +26,7 @@ const MonthNav: React.FC = () => {
   };
 
   return (
-    <RowFlexContainer width="100%" position="fixed">
+    <RowFlexContainer width="100%" position="fixed" backgroundColor="white">
       <Button color={myColor.primary.black} onClick={preMonth}>
         &lt;
       </Button>

--- a/client/src/components/molecules/MonthNav/MonthNav.tsx
+++ b/client/src/components/molecules/MonthNav/MonthNav.tsx
@@ -26,7 +26,7 @@ const MonthNav: React.FC = () => {
   };
 
   return (
-    <RowFlexContainer width="100%" position="fixed" backgroundColor="white">
+    <RowFlexContainer width="100%" position="fixed" backgroundColor="white" zIndex="7">
       <Button color={myColor.primary.black} onClick={preMonth}>
         &lt;
       </Button>

--- a/client/src/components/organisms/Calendar/Calendar.tsx
+++ b/client/src/components/organisms/Calendar/Calendar.tsx
@@ -47,6 +47,11 @@ const EmptyBox = styled.div`
   box-sizing: border-box;
 `;
 
+const MonthNavMarginBox = styled.div`
+width: 100%;
+height: 2rem; {/* <TopNavBar /> */
+`;
+
 const calendar: React.FC<Props> = ({ dateData, monthData }: Props) => {
   const dispatch = useDispatch();
   const modalView = useSelector((state: RootState) => state.modal.view);
@@ -92,6 +97,7 @@ const calendar: React.FC<Props> = ({ dateData, monthData }: Props) => {
   return (
     <Calendar>
       <MonthNav />
+      <MonthNavMarginBox />
       <Filter>
         <CheckBoxWithNumber
           checked={inCheck}

--- a/client/src/components/organisms/NewTransactionButton/NewTransactionButton.tsx
+++ b/client/src/components/organisms/NewTransactionButton/NewTransactionButton.tsx
@@ -9,7 +9,7 @@ const Container = styled.div`
 `;
 
 const FloatRightBottomContainer = styled.div`
-  position: absolute;
+  position: fixed;
   right: 1.6em;
   bottom: 1.6em;
 `;

--- a/client/src/views/AccountbookPage.tsx
+++ b/client/src/views/AccountbookPage.tsx
@@ -44,13 +44,14 @@ const Accountbook: React.FC = () => {
 
   const PaperMarginBox = styled.div`
     width: 100%;
-    height: 3rem; {/* <TopNavBar /> */
+    height: 2.9rem; {/* <TopNavBar /> */
   `;
 
   const PaperContainer = styled.div`
     width: 100%;
     position: fixed;
     z-index: 7;
+    max-width: 1200px;
   `;
   const tabStyle = {
     textDecoration: 'none',

--- a/client/src/views/CreateAccountbookPage.tsx
+++ b/client/src/views/CreateAccountbookPage.tsx
@@ -6,6 +6,7 @@ import CreateAccountbookFormBox from '@organisms/CreateAccountbookFormBox';
 import TopNavBar from '@organisms/TopNavBar';
 import CreateAccountbookSetting from '@organisms/CreateAccountbookSetting';
 import colorUtils from '@utils/color';
+import styled from 'styled-components';
 /* import * as Axios from '@utils/axios';
 import * as API from '@utils/api'; */
 
@@ -20,6 +21,12 @@ const CreateAccountbookPage: React.FC = () => {
     const result = await Axios.postAxios(API.POST_CREATE_SOCIAL, data); */
     console.log(data);
   };
+
+  const SettingContainer = styled.div`
+    width = 100%;
+    margin-bottom: 1rem;
+  `;
+
   const backgroundColor = colorUtils.getRandomColor();
   return (
     <>
@@ -30,14 +37,16 @@ const CreateAccountbookPage: React.FC = () => {
           buttonEvent={createButtonClick}
           backgroundColor={backgroundColor}
         />
-        <CreateAccountbookSetting
-          labelColor="blue"
-          links={[
-            'https://avatars2.githubusercontent.com/u/46099115?s=460&u=1e04610d430875d8189d2b212b8c2d9fc268b9db&v=4',
-            'https://avatars3.githubusercontent.com/u/55074799?s=460&u=2f70319c2f55ba5e26db060ba21d66a9cab35732&v=4',
-            'https://avatars2.githubusercontent.com/u/50297117?s=460&u=2ddc78ef0045b75f6fb405f1763304a7481d46e4&v=4',
-          ]}
-        />
+        <SettingContainer>
+          <CreateAccountbookSetting
+            labelColor="blue"
+            links={[
+              'https://avatars2.githubusercontent.com/u/46099115?s=460&u=1e04610d430875d8189d2b212b8c2d9fc268b9db&v=4',
+              'https://avatars3.githubusercontent.com/u/55074799?s=460&u=2f70319c2f55ba5e26db060ba21d66a9cab35732&v=4',
+              'https://avatars2.githubusercontent.com/u/50297117?s=460&u=2ddc78ef0045b75f6fb405f1763304a7481d46e4&v=4',
+            ]}
+          />
+        </SettingContainer>
       </CenterContent>
     </>
   );

--- a/client/src/views/StatisticsPage.tsx
+++ b/client/src/views/StatisticsPage.tsx
@@ -8,7 +8,13 @@ import FiveWeekStatistics from '@organisms/FiveWeekStatistics';
 import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
 import { getAxiosData } from '@utils/axios';
+import styled from 'styled-components';
 import * as API from '@utils/api';
+
+const MonthNavMarginBox = styled.div`
+width: 100%;
+height: 2rem; {/* <TopNavBar /> */
+`;
 
 const StatisticsPage: React.FC = () => {
   const year = useSelector((state: RootState) => state.date.year);
@@ -53,6 +59,7 @@ const StatisticsPage: React.FC = () => {
   return (
     <>
       <MonthNav />
+      <MonthNavMarginBox />
       <ToggleButton
         leftButtonName="수입"
         rightButtonName="지출"


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 달력 페이지, 일 단위 내역 페이지 금액 2줄로 출력되는 부분 수정
![image](https://user-images.githubusercontent.com/61405355/101753463-012d5700-3b16-11eb-96cd-fed5a405f08d.png)

![image](https://user-images.githubusercontent.com/61405355/101753447-f8d51c00-3b15-11eb-96d4-349f6eb9b932.png)

- 탭, 달 선택영역, 내역 추가 버튼 위치 고정
![image](https://user-images.githubusercontent.com/61405355/101753761-5b2e1c80-3b16-11eb-84ab-5a9807ac91f2.png)

   - 달 선택영역 background-color white로 설정
   - maxWidth 설정
![image](https://user-images.githubusercontent.com/61405355/101754061-aa744d00-3b16-11eb-914f-ecc112c7b0e3.png)

- 가계부 생성 페이지 하단 margin 추가

<br/>

### 📘 작업 유형

- 리펙토링

<br/>
