### PR TITLE
FE-Feat-SMS 파싱 기능 구현 및 각종 컴포넌트 리팩토링

### DIFF
--- a/client/src/components/molecules/DailyTotal/DailyTotal.tsx
+++ b/client/src/components/molecules/DailyTotal/DailyTotal.tsx
@@ -32,16 +32,24 @@ const DailyTotal = styled.div<SizeProps>`
   display: flex;
   flex-direction: row;
   align-items: center;
+  justify-content: space-between;
   width: ${(props) => props.width};
   height: ${(props) => props.height};
   border: 1px solid ${myColor.calendar.border};
   border-radius: 3px;
+  box-sizing: border-box;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
   font-size: 3px;
   color: ${myColor.primary.cancel};
 `;
 
-const TitleDiv = styled.div`
-  flex: 1;
+const AmountBox = styled.div`
+  display: flex;
+  flex-flow: row;
+  width: 45%;
+  align-items: center;
+  justify-content: space-between;
 `;
 
 const dailyTotal: React.FC<Props> = ({
@@ -63,9 +71,11 @@ const dailyTotal: React.FC<Props> = ({
   })`;
   return (
     <DailyTotal width={width} height={height}>
-      <TitleDiv>{title}</TitleDiv>
-      <Income fontWeight={fontWeight} fontSize={fontSize} color={InColor} money={InMoney} />
-      <Expenditure fontWeight={fontWeight} fontSize={fontSize} color={ExColor} money={ExMoney} />
+      <div>{title}</div>
+      <AmountBox>
+        <Income fontWeight={fontWeight} fontSize={fontSize} color={InColor} money={InMoney} />
+        <Expenditure fontWeight={fontWeight} fontSize={fontSize} color={ExColor} money={ExMoney} />
+      </AmountBox>
     </DailyTotal>
   );
 };

--- a/client/src/components/molecules/DailyTransaction/DailyTransaction.tsx
+++ b/client/src/components/molecules/DailyTransaction/DailyTransaction.tsx
@@ -19,7 +19,10 @@ interface dataProps {
 
 const DailyTransaction = styled.div`
   border: 1px solid ${myColor.calendar.border};
+  box-sizing: border-box;
   border-radius: 5px;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
   &:hover {
     background-color: ${myColor.calendar.main};
     transform: scale(1.2);

--- a/client/src/components/molecules/Modal/Modal.tsx
+++ b/client/src/components/molecules/Modal/Modal.tsx
@@ -25,7 +25,9 @@ const defaultProps = {
 };
 
 const ModalBackground = styled.div`
-  position: absolute;
+  position: fixed;
+  top: 0;
+  left: 0;
   width: 100vw;
   height: 100vh;
   background-color: ${myColor.background.translucentBlack};
@@ -34,6 +36,8 @@ const ModalBackground = styled.div`
 
 const ModalContainer = styled.div`
   position: absolute;
+  top: 0;
+  left: 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -50,7 +54,7 @@ const Modal = styled.div<modalProps>`
   border: 0;
   border-radius: 8px;
   padding: 10px 40px;
-  z-index: 4;
+  z-index: 10;
 `;
 
 const ButtonContainer = styled.div`

--- a/client/src/components/molecules/Modal/Modal.tsx
+++ b/client/src/components/molecules/Modal/Modal.tsx
@@ -31,7 +31,7 @@ const ModalBackground = styled.div`
   width: 100vw;
   height: 100vh;
   background-color: ${myColor.background.translucentBlack};
-  z-index: 3;
+  z-index: 10;
 `;
 
 const ModalContainer = styled.div`
@@ -54,7 +54,7 @@ const Modal = styled.div<modalProps>`
   border: 0;
   border-radius: 8px;
   padding: 10px 40px;
-  z-index: 10;
+  z-index: 20;
 `;
 
 const ButtonContainer = styled.div`

--- a/client/src/components/molecules/Modal/Modal.tsx
+++ b/client/src/components/molecules/Modal/Modal.tsx
@@ -20,7 +20,7 @@ interface modalProps {
 
 const defaultProps = {
   title: '',
-  width: '80%',
+  width: '70%',
   height: '60%',
 };
 

--- a/client/src/components/molecules/TransactionInfo/TransactionInfo.tsx
+++ b/client/src/components/molecules/TransactionInfo/TransactionInfo.tsx
@@ -32,6 +32,7 @@ const TransactionInfo: React.FC<props> = ({ data }: props) => {
         <RoundShortChips
           backgroundColor={data.payment === null ? myColor.primary.main : myColor.primary.accent}
           margin="0px 10px 0px 0px"
+          fontSize="0.5rem"
         >
           {data.category}
         </RoundShortChips>

--- a/client/src/components/organisms/CreateTransactionHeader/CreateTransactionHeader.tsx
+++ b/client/src/components/organisms/CreateTransactionHeader/CreateTransactionHeader.tsx
@@ -4,6 +4,8 @@ import myColor from '@theme/color';
 import Text from '@atoms/p/LeftLargeText';
 import Button from '@atoms/button/IconDetailButton';
 import FlexContainer from '@atoms/div/RowFlexContainer';
+import { useDispatch } from 'react-redux';
+import { showModal } from '@actions/modal/type';
 
 interface Props {
   margin: string;
@@ -14,6 +16,10 @@ const Container = styled.div<Props>`
 `;
 
 const createTransactionHeader: React.FC = () => {
+  const dispatch = useDispatch();
+  const openModal = (view: string) => {
+    dispatch(showModal(view));
+  };
   return (
     <FlexContainer width="100%" margin="4rem 0 0">
       <Text>새로운 내역을 추가해보세요!</Text>
@@ -21,7 +27,7 @@ const createTransactionHeader: React.FC = () => {
         <Button name="csv" color={myColor.primary.green} />
       </Container>
       <Container margin="24px">
-        <Button name="sms" />
+        <Button name="sms" onClick={() => openModal('sms')} />
       </Container>
     </FlexContainer>
   );

--- a/client/src/components/organisms/FourMonthStatistics/FourMonthStatistics.tsx
+++ b/client/src/components/organisms/FourMonthStatistics/FourMonthStatistics.tsx
@@ -68,9 +68,9 @@ const PressedMonthBtn = styled.div`
 
 const FourMonthStatistics: React.FC<props> = ({ data }: props) => {
   let maxHeight = 0;
-  const monthList = getPastMonthList(4);
+  const monthList = getPastMonthList(4).reverse();
 
-  const [monthIndex, setMonthIndex] = useState(0);
+  const [monthIndex, setMonthIndex] = useState(3);
 
   const changeMonth = (index) => {
     setMonthIndex(index);

--- a/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
+++ b/client/src/components/organisms/MonthTransaction/MonthTransaction.tsx
@@ -23,6 +23,7 @@ const Filter = styled.div`
 
 const MonthTransaction = styled.div`
   border: 1px solid ${Color.calendar.border};
+  box-sizing: border-box;
   border-radius: 5px;
 `;
 

--- a/client/src/components/organisms/NewTransactionButton/NewTransactionButton.tsx
+++ b/client/src/components/organisms/NewTransactionButton/NewTransactionButton.tsx
@@ -2,12 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import CreateButton from '@atoms/button/CreateButton';
 
-const Container = styled.div`
-  position: relative;
-  width: 100%;
-  height: 100%;
-`;
-
 const FloatRightBottomContainer = styled.div`
   position: fixed;
   right: 1.6em;
@@ -17,11 +11,11 @@ const FloatRightBottomContainer = styled.div`
 const NewTransactionButton: React.FC = () => {
   const link = '/accountbook/transaction/new';
   return (
-    <Container>
+    <>
       <FloatRightBottomContainer>
         <CreateButton link={link} />
       </FloatRightBottomContainer>
-    </Container>
+    </>
   );
 };
 

--- a/client/src/components/organisms/SmsParsingModal/SmsParsingModal.stories.tsx
+++ b/client/src/components/organisms/SmsParsingModal/SmsParsingModal.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import SmsParsingModal from './SmsParsingModal';
+
+export default {
+  title: 'Organisms/SmsParsingModal',
+  component: SmsParsingModal,
+};
+
+export const smsParsingModal = (): JSX.Element => {
+  return <SmsParsingModal />;
+};
+
+smsParsingModal.story = {
+  name: 'SmsParsingModal',
+};

--- a/client/src/components/organisms/SmsParsingModal/SmsParsingModal.stories.tsx
+++ b/client/src/components/organisms/SmsParsingModal/SmsParsingModal.stories.tsx
@@ -7,7 +7,7 @@ export default {
 };
 
 export const smsParsingModal = (): JSX.Element => {
-  return <SmsParsingModal />;
+  return <SmsParsingModal setData={() => undefined} />;
 };
 
 smsParsingModal.story = {

--- a/client/src/components/organisms/SmsParsingModal/SmsParsingModal.tsx
+++ b/client/src/components/organisms/SmsParsingModal/SmsParsingModal.tsx
@@ -71,8 +71,8 @@ const SmsParsingModal: React.FC<props> = ({ setData }: props) => {
       if (data.includes(':')) {
         newData.time = data.match(/[0-9]{2}:[0-9]{2}/)[0];
       }
-      if (data.includes('/')) {
-        newData.date = data.match(/[0-9]{2}\/[0-9]{2}/)[0];
+      if (data.includes('-')) {
+        newData.date = data.match(/[0-9]{2}-[0-9]{2}/)[0];
       }
     });
     return newData;

--- a/client/src/components/organisms/SmsParsingModal/SmsParsingModal.tsx
+++ b/client/src/components/organisms/SmsParsingModal/SmsParsingModal.tsx
@@ -1,0 +1,97 @@
+/* eslint-disable prefer-destructuring */
+import React, { useState } from 'react';
+import Modal from '@molecules/Modal';
+import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
+import RoundLongButton from '@atoms/button/RoundLongButton';
+import TextArea from '@atoms/textarea/TextArea';
+import { hideModal } from '@actions/modal/type';
+import { useDispatch } from 'react-redux';
+
+const SmsParsingModal: React.FC = () => {
+  const [message, setMessage] = useState('');
+  const dispatch = useDispatch();
+  const closeModal = () => {
+    dispatch(hideModal());
+  };
+  const title = 'SMS 입력하기';
+
+  const changeHandler = (event) => {
+    setMessage(event.target.value);
+    console.log(message);
+  };
+
+  const paymentList = [
+    'SC제일',
+    '카카오뱅크',
+    '농협',
+    'IBK기업',
+    '하나은행',
+    '우리',
+    '국민',
+    '대구',
+    '부산',
+    '광주',
+    '새마을',
+    '우체국',
+    '신협',
+    '저축은행',
+    '신한',
+  ];
+
+  const parseSMS = (string) => {
+    return string
+      .replace(/\[web발신\]/i, '')
+      .trim()
+      .split(/[\s\n\r]/g)
+      .filter((e) => e);
+  };
+
+  const solution = (sms) => {
+    const newData: any = {};
+
+    newData.cardName = undefined;
+    paymentList.forEach((card) => {
+      if (sms.match(card)) {
+        newData.cardName = card;
+        console.log('카드이름은', card);
+      }
+    });
+    const parsedSMSDatas = parseSMS(sms);
+    parsedSMSDatas.forEach((data) => {
+      if (data.includes('원') && !newData.amount) {
+        newData.amount = Number(data.match(/[0-9]+(,?[0-9]+)+/)[0].replace(',', ''));
+        return;
+      }
+      if (data.includes(':')) {
+        newData.time = data.match(/[0-9]{2}:[0-9]{2}/)[0];
+      }
+      if (data.includes('/')) {
+        newData.date = data.match(/[0-9]{2}\/[0-9]{2}/)[0];
+      }
+    });
+    return newData;
+  };
+
+  return (
+    <Modal title={title}>
+      <ColumnFlexContainer
+        width="100%"
+        height="100%"
+        alignItems="center"
+        justifyContent="space-evenly"
+      >
+        <TextArea width="100%" height="60%" value={message} onChange={changeHandler} />
+        <RoundLongButton
+          onClick={() => {
+            closeModal();
+            solution(message);
+          }}
+        >
+          등록
+        </RoundLongButton>
+      </ColumnFlexContainer>
+    </Modal>
+  );
+};
+
+export default SmsParsingModal;

--- a/client/src/components/organisms/SmsParsingModal/SmsParsingModal.tsx
+++ b/client/src/components/organisms/SmsParsingModal/SmsParsingModal.tsx
@@ -7,7 +7,11 @@ import TextArea from '@atoms/textarea/TextArea';
 import { hideModal } from '@actions/modal/type';
 import { useDispatch } from 'react-redux';
 
-const SmsParsingModal: React.FC = () => {
+interface props {
+  setData: any;
+}
+
+const SmsParsingModal: React.FC<props> = ({ setData }: props) => {
   const [message, setMessage] = useState('');
   const dispatch = useDispatch();
   const closeModal = () => {
@@ -17,7 +21,10 @@ const SmsParsingModal: React.FC = () => {
 
   const changeHandler = (event) => {
     setMessage(event.target.value);
-    console.log(message);
+  };
+
+  const submitHandler = (parsedData) => {
+    setData(parsedData);
   };
 
   const paymentList = [
@@ -53,7 +60,6 @@ const SmsParsingModal: React.FC = () => {
     paymentList.forEach((card) => {
       if (sms.match(card)) {
         newData.cardName = card;
-        console.log('카드이름은', card);
       }
     });
     const parsedSMSDatas = parseSMS(sms);
@@ -83,8 +89,8 @@ const SmsParsingModal: React.FC = () => {
         <TextArea width="100%" height="60%" value={message} onChange={changeHandler} />
         <RoundLongButton
           onClick={() => {
+            submitHandler(solution(message));
             closeModal();
-            solution(message);
           }}
         >
           등록

--- a/client/src/components/organisms/SmsParsingModal/index.ts
+++ b/client/src/components/organisms/SmsParsingModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SmsParsingModal';

--- a/client/src/components/organisms/TransactionForm/TransactionForm.tsx
+++ b/client/src/components/organisms/TransactionForm/TransactionForm.tsx
@@ -13,6 +13,7 @@ import { getDate, getTime } from '@utils/date';
 import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
 import { postData } from '@interfaces/transaction';
+import SmsParsingModal from '@organisms/SmsParsingModal';
 
 interface Props {
   initData?: postData | undefined;
@@ -41,7 +42,7 @@ const transactionForm: React.FC<Props> = ({ initData }: Props) => {
   const income = useSelector((state: RootState) => state.category.income);
   const expenditure = useSelector((state: RootState) => state.category.expenditure);
   const payment = useSelector((state: RootState) => state.payment.payment);
-
+  const modalView = useSelector((state: RootState) => state.modal.view);
   const [isIncome, setIsIncome] = useState(true);
   const [isExpenditure, setIsExpenditure] = useState(false);
 
@@ -51,6 +52,7 @@ const transactionForm: React.FC<Props> = ({ initData }: Props) => {
   const [time, setTime] = useState<string>();
   const [categoryId, setCategoryId] = useState<number | string>();
   const [paymentId, setPaymentId] = useState<number | string>();
+  const [parsedData, setParsedData] = useState(undefined);
 
   const titleInputChange = (e) => {
     const input = e.target.value;
@@ -99,76 +101,83 @@ const transactionForm: React.FC<Props> = ({ initData }: Props) => {
     }
   }, []);
 
+  useEffect(() => {
+    console.log(parsedData);
+  }, [parsedData]);
+
   return (
-    <ColumnFlexContainer width="100%" justifyContent="space-around">
-      <RowFlexContainer width="100%" alignItems="center">
-        <ToggleButton
-          leftButtonName="수입"
-          rightButtonName="지출"
-          leftCallback={setIsIncome}
-          rightCallback={setIsExpenditure}
-        />
-        <DeleteButtonContainer>
-          <TextButton onClick={clearInput}>모두 지우기</TextButton>
-        </DeleteButtonContainer>
-      </RowFlexContainer>
-      <InputContainer>
-        <InputDiv>
-          <Input
-            fontSize="1.4rem"
-            placeholder="최대 15자까지 입력가능합니다"
-            width="100%"
-            value={title}
-            onChange={titleInputChange}
+    <>
+      {modalView !== 'none' ? <SmsParsingModal setData={setParsedData} /> : undefined}
+      <ColumnFlexContainer width="100%" justifyContent="space-around">
+        <RowFlexContainer width="100%" alignItems="center">
+          <ToggleButton
+            leftButtonName="수입"
+            rightButtonName="지출"
+            leftCallback={setIsIncome}
+            rightCallback={setIsExpenditure}
           />
-        </InputDiv>
-        <InputWithText title="금액" width="100%" value={amount} onChange={amountInputChange} />
-        <RowFlexContainer justifyContent="space-between">
-          <DateWithText
-            type="date"
-            title="날짜"
-            width="55%"
-            value={date}
-            onChange={(e) => inputChange(e, setDate)}
-          />
-          <DateWithText
-            type="time"
-            title="시간"
-            width="45%"
-            justifyContent="flex-end"
-            value={time}
-            onChange={(e) => inputChange(e, setTime)}
-          />
+          <DeleteButtonContainer>
+            <TextButton onClick={clearInput}>모두 지우기</TextButton>
+          </DeleteButtonContainer>
         </RowFlexContainer>
-        {isIncome && (
+        <InputContainer>
+          <InputDiv>
+            <Input
+              fontSize="1.4rem"
+              placeholder="최대 15자까지 입력가능합니다"
+              width="100%"
+              value={title}
+              onChange={titleInputChange}
+            />
+          </InputDiv>
+          <InputWithText title="금액" width="100%" value={amount} onChange={amountInputChange} />
+          <RowFlexContainer justifyContent="space-between">
+            <DateWithText
+              type="date"
+              title="날짜"
+              width="55%"
+              value={date}
+              onChange={(e) => inputChange(e, setDate)}
+            />
+            <DateWithText
+              type="time"
+              title="시간"
+              width="45%"
+              justifyContent="flex-end"
+              value={time}
+              onChange={(e) => inputChange(e, setTime)}
+            />
+          </RowFlexContainer>
+          {isIncome && (
+            <MenuWithText
+              options={income}
+              title="카테고리"
+              width="100%"
+              value={categoryId}
+              onChange={(e) => inputChange(e, setCategoryId)}
+            />
+          )}
+          {isExpenditure && (
+            <MenuWithText
+              options={expenditure}
+              title="카테고리"
+              width="100%"
+              value={categoryId}
+              onChange={(e) => inputChange(e, setCategoryId)}
+            />
+          )}
           <MenuWithText
-            options={income}
-            title="카테고리"
+            options={payment}
+            title="결제수단"
             width="100%"
-            value={categoryId}
-            onChange={(e) => inputChange(e, setCategoryId)}
+            value={paymentId}
+            onChange={(e) => inputChange(e, setPaymentId)}
+            isIncome={isIncome}
           />
-        )}
-        {isExpenditure && (
-          <MenuWithText
-            options={expenditure}
-            title="카테고리"
-            width="100%"
-            value={categoryId}
-            onChange={(e) => inputChange(e, setCategoryId)}
-          />
-        )}
-        <MenuWithText
-          options={payment}
-          title="결제수단"
-          width="100%"
-          value={paymentId}
-          onChange={(e) => inputChange(e, setPaymentId)}
-          isIncome={isIncome}
-        />
-        <input readOnly value={Number(isIncome)} hidden />
-      </InputContainer>
-    </ColumnFlexContainer>
+          <input readOnly value={Number(isIncome)} hidden />
+        </InputContainer>
+      </ColumnFlexContainer>
+    </>
   );
 };
 

--- a/client/src/components/organisms/TransactionForm/TransactionForm.tsx
+++ b/client/src/components/organisms/TransactionForm/TransactionForm.tsx
@@ -45,6 +45,7 @@ const transactionForm: React.FC<Props> = ({ initData }: Props) => {
   const modalView = useSelector((state: RootState) => state.modal.view);
   const [isIncome, setIsIncome] = useState(true);
   const [isExpenditure, setIsExpenditure] = useState(false);
+  const currDate = new Date();
 
   const [title, setTitle] = useState<string>();
   const [amount, setAmount] = useState<string>();
@@ -52,7 +53,12 @@ const transactionForm: React.FC<Props> = ({ initData }: Props) => {
   const [time, setTime] = useState<string>();
   const [categoryId, setCategoryId] = useState<number | string>();
   const [paymentId, setPaymentId] = useState<number | string>();
-  const [parsedData, setParsedData] = useState(undefined);
+  const [parsedData, setParsedData] = useState({
+    cardName: undefined,
+    amount: undefined,
+    date: undefined,
+    time: undefined,
+  });
 
   const titleInputChange = (e) => {
     const input = e.target.value;
@@ -102,7 +108,18 @@ const transactionForm: React.FC<Props> = ({ initData }: Props) => {
   }, []);
 
   useEffect(() => {
-    console.log(parsedData);
+    if (parsedData.amount !== undefined) {
+      const amountNumber = Number(parsedData.amount);
+      setAmount(numberToMoney(amountNumber));
+    }
+
+    if (parsedData.time !== undefined) setTime(parsedData.time);
+    if (parsedData.date !== undefined) setDate(`${currDate.getFullYear()}-${parsedData.date}`);
+    if (parsedData.cardName !== undefined) {
+      payment.forEach((el) => {
+        if (el.name === parsedData.cardName) setPaymentId(el.id);
+      });
+    }
   }, [parsedData]);
 
   return (

--- a/client/src/views/StatisticsPage.tsx
+++ b/client/src/views/StatisticsPage.tsx
@@ -33,7 +33,7 @@ const StatisticsPage: React.FC = () => {
       accountbookType === 'SOCIAL'
         ? await getAxiosData(API.GET_SOCIAL_FOUR_MONTH_STATISTICS(accountbookId))
         : await getAxiosData(API.GET_PRIVATE_FOUR_MONTH_STATISTICS);
-    setFourMonthData(master.data.reverse());
+    setFourMonthData(master.data);
   };
 
   const initFiveWeekData = async () => {

--- a/client/src/views/TransactionPostPage.tsx
+++ b/client/src/views/TransactionPostPage.tsx
@@ -11,6 +11,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
 import { postAxios } from '@utils/axios';
 import * as API from '@utils/api';
+import SmsParsingModal from '@organisms/SmsParsingModal';
 
 // eslint-disable-next-line no-shadow
 enum Form {
@@ -30,6 +31,7 @@ const Container = styled.div`
 const TransactionPostPage: React.FC = () => {
   const accountbookType = useSelector((state: RootState) => state.accountbook.type);
   const accountbookId = useSelector((state: RootState) => state.accountbook.socialId);
+  const modalView = useSelector((state: RootState) => state.modal.view);
 
   const history = useHistory();
   const cancel = () => {
@@ -73,6 +75,7 @@ const TransactionPostPage: React.FC = () => {
 
   return (
     <>
+      {modalView !== 'none' ? <SmsParsingModal /> : undefined}
       <CenterContent>
         <TopNavBar />
         <Container>

--- a/client/src/views/TransactionPostPage.tsx
+++ b/client/src/views/TransactionPostPage.tsx
@@ -11,7 +11,6 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
 import { postAxios } from '@utils/axios';
 import * as API from '@utils/api';
-import SmsParsingModal from '@organisms/SmsParsingModal';
 
 // eslint-disable-next-line no-shadow
 enum Form {
@@ -31,7 +30,6 @@ const Container = styled.div`
 const TransactionPostPage: React.FC = () => {
   const accountbookType = useSelector((state: RootState) => state.accountbook.type);
   const accountbookId = useSelector((state: RootState) => state.accountbook.socialId);
-  const modalView = useSelector((state: RootState) => state.modal.view);
 
   const history = useHistory();
   const cancel = () => {
@@ -75,7 +73,6 @@ const TransactionPostPage: React.FC = () => {
 
   return (
     <>
-      {modalView !== 'none' ? <SmsParsingModal /> : undefined}
       <CenterContent>
         <TopNavBar />
         <Container>


### PR DESCRIPTION
### 📕 Issue Number

Close #99 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 최근 4개월 통계 그래프 배치 순서 변경
![image](https://user-images.githubusercontent.com/55074799/101803519-f5f91c00-3b53-11eb-82af-416d0defa126.png)

- SMS 파싱용 Modal 생성
- Modal의 좌/우가 가득 차던 디자인 수정
![image](https://user-images.githubusercontent.com/55074799/101803609-1032fa00-3b54-11eb-9fb1-876af443d11b.png)

- 달력 페이지에서 modal과 상단바의 Z-index 간섭 문제 수정
![image](https://user-images.githubusercontent.com/55074799/101803811-453f4c80-3b54-11eb-968c-d04c051949fa.png)

- Transaction Create Button이 페이지에서 width와 height를 차지하던 문제 수정
  - 페이지 전체에 스크롤이 생기던 문제가 해결된 것을 볼 수 있습니다
![image](https://user-images.githubusercontent.com/55074799/101804306-c991cf80-3b54-11eb-87b3-3b2591d146eb.png)

- SMS 파싱 기능 구현
![smsparse](https://user-images.githubusercontent.com/55074799/101804220-b3840f00-3b54-11eb-9f39-b1019764b8f9.gif)

- 내역 페이지 여백 및 border 조정
  - box-sizing 옵션을 적용하여 레이아웃이 틀어지던 버그를 수정했습니다
  - 카테고리 Chips의 폰트 크기를 조정하여 5글자 이상에서 발생하던 줄 바뀜 문제를 해결했습니다
![image](https://user-images.githubusercontent.com/55074799/101804493-fba33180-3b54-11eb-85d5-9f778008f184.png)

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 리펙토링

<br/>
