### PR TITLE
FULL-feat-creditCardEditModal 결재수단 관리 모달 UI 수정 및 관련 API 구현

### DIFF
--- a/client/src/components/atoms/div/ColumnFlexContainer/ColumnFlexContainer.tsx
+++ b/client/src/components/atoms/div/ColumnFlexContainer/ColumnFlexContainer.tsx
@@ -10,6 +10,7 @@ interface Props {
   width?: string;
   height?: string;
   flexWrap?: string;
+  zIndex?: string;
 }
 
 const defaultProps = {
@@ -20,6 +21,7 @@ const defaultProps = {
   width: '',
   height: '',
   flexWrap: 'nowrap',
+  zIndex: 'auto',
 };
 
 const Div = styled.div<Props>`
@@ -32,6 +34,7 @@ const Div = styled.div<Props>`
   width: ${(props) => props.width};
   height: ${(props) => props.height};
   flex-wrap: ${(props) => props.flexWrap};
+  z-index: ${(props) => props.zIndex};
 `;
 
 const ColumnFlexContainer: React.FC<Props> = ({ children, ...props }: Props) => {

--- a/client/src/components/molecules/CreditCard/CreditCard.tsx
+++ b/client/src/components/molecules/CreditCard/CreditCard.tsx
@@ -5,17 +5,31 @@ import CenterNormalText from '@atoms/p/CenterNormalText';
 import IconButton from '@atoms/button/IconButton';
 import Line from '@atoms/hr/Line';
 import MinusIcon from '@svg/minus.svg';
+import styled from 'styled-components';
 
 interface Props {
   name: string;
 }
 
+const TextContainer = styled.div`
+  padding-top: 0.7rem;
+  flex: 5;
+`;
+
+const IconButtonContainer = styled.div`
+  flex: 1;
+`;
+
 const CreditCard: React.FC<Props> = ({ name }: Props) => {
   return (
     <ColumnFlexContainer width="100%">
       <RowFlexContainer width="100%" justifyContent="space-around">
-        <CenterNormalText>{name}</CenterNormalText>
-        <IconButton>{MinusIcon}</IconButton>
+        <TextContainer>
+          <CenterNormalText>{name}</CenterNormalText>
+        </TextContainer>
+        <IconButtonContainer>
+          <IconButton>{MinusIcon}</IconButton>
+        </IconButtonContainer>
       </RowFlexContainer>
       <Line widthPercent="110" margin="0 0.5rem 0 0" />
     </ColumnFlexContainer>

--- a/client/src/components/organisms/CreditCardEditCardList/CreditCardEditCardList.stories.tsx
+++ b/client/src/components/organisms/CreditCardEditCardList/CreditCardEditCardList.stories.tsx
@@ -1,26 +1,15 @@
 import React from 'react';
 import CreditCardEditCardList from './CreditCardEditCardList';
 
-interface Props {
-  cardNameList: string[];
-}
-
 export default {
   title: 'Organisms/CreditCardEditCardList',
   component: CreditCardEditCardList,
-  argTypes: {
-    cardNameList: { control: 'text' },
-  },
 };
 
-export const creditCardEditCardList = ({ ...args }: Props): JSX.Element => {
-  return <CreditCardEditCardList {...args} />;
+export const creditCardEditCardList = (): JSX.Element => {
+  return <CreditCardEditCardList />;
 };
 
 creditCardEditCardList.story = {
   name: 'CreditCardEditCardList',
-};
-
-creditCardEditCardList.args = {
-  cardNameList: ['신한카드', '하나카드', '농협카드'],
 };

--- a/client/src/components/organisms/CreditCardEditCardList/CreditCardEditCardList.tsx
+++ b/client/src/components/organisms/CreditCardEditCardList/CreditCardEditCardList.tsx
@@ -1,33 +1,10 @@
 import React from 'react';
-import styled from 'styled-components';
-import CreditCard from '@molecules/CreditCard';
-import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
+/* import styled from 'styled-components';
+import CreditCard from '@molecules/CreditCard'; */
+// import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
 
-interface Props {
-  cardNameList: string[];
-}
-
-const ScrollDiv = styled.div`
-  overflow: scroll;
-  ::-webkit-scrollbar {
-    display: none;
-  }
-  display: flex;
-  flex-flow: column;
-  width: 100%;
-  height: 90%;
-`;
-
-const CreditCardEditCardList: React.FC<Props> = ({ cardNameList }: Props) => {
-  return (
-    <ColumnFlexContainer width="100%" margin="2rem 0 0 0" justifyContent="space-between">
-      <ScrollDiv>
-        {cardNameList.map((cardName) => (
-          <CreditCard name={cardName} />
-        ))}
-      </ScrollDiv>
-    </ColumnFlexContainer>
-  );
+const CreditCardEditCardList: React.FC = () => {
+  return <></>;
 };
 
 export default CreditCardEditCardList;

--- a/client/src/components/organisms/CreditCardEditFormBox/CreditCardEditFormBox.stories.tsx
+++ b/client/src/components/organisms/CreditCardEditFormBox/CreditCardEditFormBox.stories.tsx
@@ -6,8 +6,12 @@ export default {
   component: CreditCardEditFormBox,
 };
 
+const testFunc = (data: any) => {
+  return data;
+};
+
 export const creditCardEditFormBox = (): JSX.Element => {
-  return <CreditCardEditFormBox />;
+  return <CreditCardEditFormBox buttonEvent={() => testFunc([1, 2, 3])} />;
 };
 
 creditCardEditFormBox.story = {

--- a/client/src/components/organisms/CreditCardEditFormBox/CreditCardEditFormBox.tsx
+++ b/client/src/components/organisms/CreditCardEditFormBox/CreditCardEditFormBox.tsx
@@ -5,7 +5,11 @@ import LeftSmallText from '@atoms/p/LeftSmallText';
 import RoundShortButton from '@atoms/button/RoundShortButton';
 import Input from '@atoms/input/Input';
 
-const CreditCardEditFormBox: React.FC = () => {
+interface Props {
+  buttonEvent: (data) => any;
+}
+
+const CreditCardEditFormBox: React.FC<Props> = ({ buttonEvent }: Props) => {
   const [name, setName] = useState('');
 
   const nameChangeHandler = (event: any) => {
@@ -16,7 +20,7 @@ const CreditCardEditFormBox: React.FC = () => {
       <LeftSmallText>결재 수단 이름</LeftSmallText>
       <RowFlexContainer width="100%" margin="2rem 0 0 0 " justifyContent="space-between">
         <Input width="70%" value={name} onChange={nameChangeHandler} />
-        <RoundShortButton>등록</RoundShortButton>
+        <RoundShortButton onClick={() => buttonEvent(name)}>등록</RoundShortButton>
       </RowFlexContainer>
     </ColumnFlexContainer>
   );

--- a/client/src/components/organisms/CreditCardEditFormBox/CreditCardEditFormBox.tsx
+++ b/client/src/components/organisms/CreditCardEditFormBox/CreditCardEditFormBox.tsx
@@ -1,16 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import LeftSmallText from '@atoms/p/LeftSmallText';
 import RoundShortButton from '@atoms/button/RoundShortButton';
-import Line from '@atoms/hr/Line';
+import Input from '@atoms/input/Input';
 
 const CreditCardEditFormBox: React.FC = () => {
+  const [name, setName] = useState('');
+
+  const nameChangeHandler = (event: any) => {
+    setName(event.target.value);
+  };
   return (
     <ColumnFlexContainer width="100%" margin="0 0 2rem 0" alignItems="baseline">
       <LeftSmallText>결재 수단 이름</LeftSmallText>
       <RowFlexContainer width="100%" margin="2rem 0 0 0 " justifyContent="space-between">
-        <Line widthPercent="100" margin="2rem 3rem 0 0" />
+        <Input width="70%" value={name} onChange={nameChangeHandler} />
         <RoundShortButton>등록</RoundShortButton>
       </RowFlexContainer>
     </ColumnFlexContainer>

--- a/client/src/components/organisms/CreditCardEditModal/CreditCardEditModal.tsx
+++ b/client/src/components/organisms/CreditCardEditModal/CreditCardEditModal.tsx
@@ -28,7 +28,7 @@ const CreditCardEditModal: React.FC = () => {
     console.log(result);
   };
 
-  const cardNameList = ['신한카드', '하나카드', '카카오페이', '신한카드', '하나카드', '카카오페이'];
+  const cardNameList = ['하나카드', '카카오페이', '신한카드'];
   const cardList = cardNameList.map((cardName) => <CreditCard name={cardName} />);
   return (
     <Modal title={title}>

--- a/client/src/components/organisms/CreditCardEditModal/CreditCardEditModal.tsx
+++ b/client/src/components/organisms/CreditCardEditModal/CreditCardEditModal.tsx
@@ -5,6 +5,8 @@ import Line from '@atoms/hr/Line';
 import myColor from '@theme/color';
 import styled from 'styled-components';
 import CreditCard from '@molecules/CreditCard';
+import * as Axios from '@utils/axios';
+import * as API from '@utils/api';
 
 const ScrollDiv = styled.div`
   overflow: scroll;
@@ -20,16 +22,12 @@ const ScrollDiv = styled.div`
 const CreditCardEditModal: React.FC = () => {
   const title = '결제 수단 관리';
 
-  const createButtonClick = async (data: any) => {
-    /* const data = {
-      name,
-      description,
-      usersList,
-      color,
-    };
-    const result = await Axios.postAxios(API.POST_CREATE_SOCIAL, data); */
-    console.log(data);
+  const createButtonClick = async (name: any) => {
+    const result = await Axios.postAxios(API.POST_PAYMENT, name);
+
+    console.log(result);
   };
+
   const cardNameList = ['신한카드', '하나카드', '카카오페이', '신한카드', '하나카드', '카카오페이'];
   const cardList = cardNameList.map((cardName) => <CreditCard name={cardName} />);
   return (

--- a/client/src/components/organisms/CreditCardEditModal/CreditCardEditModal.tsx
+++ b/client/src/components/organisms/CreditCardEditModal/CreditCardEditModal.tsx
@@ -1,30 +1,42 @@
 import React from 'react';
 import Modal from '@molecules/Modal';
-import ColumnFlexContainer from '@atoms/div/ColumnFlexContainer';
 import CreditCardEditFormBox from '@organisms/CreditCardEditFormBox';
-import CreditCardEditCardList from '@organisms/CreditCardEditCardList';
 import Line from '@atoms/hr/Line';
 import myColor from '@theme/color';
+import styled from 'styled-components';
+import CreditCard from '@molecules/CreditCard';
+
+const ScrollDiv = styled.div`
+  overflow: scroll;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  display: flex;
+  flex-flow: column;
+  width: 100%;
+  height: 90%;
+`;
 
 const CreditCardEditModal: React.FC = () => {
   const title = '결제 수단 관리';
 
+  const createButtonClick = async (data: any) => {
+    /* const data = {
+      name,
+      description,
+      usersList,
+      color,
+    };
+    const result = await Axios.postAxios(API.POST_CREATE_SOCIAL, data); */
+    console.log(data);
+  };
+  const cardNameList = ['신한카드', '하나카드', '카카오페이', '신한카드', '하나카드', '카카오페이'];
+  const cardList = cardNameList.map((cardName) => <CreditCard name={cardName} />);
   return (
     <Modal title={title}>
-      <ColumnFlexContainer width="100%" justifyContent="space-between" margin="2rem 0 0 0">
-        <CreditCardEditFormBox />
-        <Line widthPercent="110" height="0.25rem" lineColor={myColor.primary.lightGray} />
-        <CreditCardEditCardList
-          cardNameList={[
-            '신한카드',
-            '하나카드',
-            '카카오페이',
-            '신한카드',
-            '하나카드',
-            '카카오페이',
-          ]}
-        />
-      </ColumnFlexContainer>
+      <CreditCardEditFormBox buttonEvent={createButtonClick} />
+      <Line widthPercent="110" height="0.25rem" lineColor={myColor.primary.lightGray} />
+      <ScrollDiv>{cardList}</ScrollDiv>
     </Modal>
   );
 };

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -37,3 +37,7 @@ export const GET_PRIVATE_FOUR_MONTH_STATISTICS = `${process.env.REACT_APP_BASE_U
 export const POST_PRIVATE_TRANSACTION = `${process.env.REACT_APP_BASE_URL}/api/private/transaction`;
 
 export const POST_SOCIAL_TRANSACTION = `${process.env.REACT_APP_BASE_URL}/api/social/transaction`;
+
+export const POST_PAYMENT = `${process.env.REACT_APP_BASE_URL}/api/payment`;
+
+export const DELETE_PAYMENT = `${process.env.REACT_APP_BASE_URL}/api/payment`;

--- a/server/src/model/query/paymentQuery.ts
+++ b/server/src/model/query/paymentQuery.ts
@@ -3,6 +3,19 @@ const paymentQuery = {
     SELECT user_payment.id, payment.name
     FROM user_payment LEFT OUTER JOIN payment ON user_payment.payment_id = payment.id
     WHERE user_payment.user_id = ?`,
+  CREATE_USER_PAYMENTS: `
+    INSERT into user_payment (user_id, payment_id) VALUES(?,?)
+    `,
+  READ_PAYMENTS: `
+    SELECT name From payment
+  `,
+  CREATE_PAYMENTS: `
+    INSERT into payment (name) VALUES(?)
+  `,
+
+  GET_PAYMENT_ID_BY_NAME: `
+    SELECT id FROM payment WHERE name = ?
+  `,
 };
 
 export default paymentQuery;

--- a/server/src/payment/controller.ts
+++ b/server/src/payment/controller.ts
@@ -3,10 +3,31 @@ import * as response from '../utils/response';
 import 'dotenv/config';
 import * as Service from './service';
 
-export const getPayments = async (ctx: Context) => {
+export const getUserPayments = async (ctx: Context) => {
   const userId = ctx.userData.uid;
-  const result = await Service.getPayments(userId);
+  const result = await Service.getUserPayments(userId);
   response.success(ctx, result);
 };
 
-export default getPayments;
+export const createUserPayments = async (ctx: any) => {
+  const { names } = ctx.request.body;
+  const userId = ctx.userData.uid;
+
+  let createPaymentResult;
+  let createUserPaymentResult;
+  let checkInclude;
+  let newUserPaymentId;
+
+  for (const name of names) {
+    checkInclude = await Service.getPaymentIdByName(name);
+    if (checkInclude.length === 0) {
+      createPaymentResult = await Service.createPayments(name);
+      newUserPaymentId = createPaymentResult.insertId;
+    } else {
+      newUserPaymentId = checkInclude[0].id;
+    }
+    createUserPaymentResult = await Service.createUserPayments(userId, newUserPaymentId);
+  }
+
+  response.success(ctx, createUserPaymentResult.insertId);
+};

--- a/server/src/payment/router.ts
+++ b/server/src/payment/router.ts
@@ -4,6 +4,7 @@ const Router = require('@koa/router');
 
 const router = new Router();
 
-router.get('/', Controller.getPayments);
+router.get('/', Controller.getUserPayments);
+router.post('/', Controller.createUserPayments);
 
 export default router;

--- a/server/src/payment/service.ts
+++ b/server/src/payment/service.ts
@@ -2,9 +2,27 @@ import 'dotenv/config';
 import sql from '../model/db';
 import query from '../model/query';
 
-export const getPayments = async (userId: number) => {
+export const getUserPayments = async (userId: number) => {
   const result = await sql(query.READ_USER_PAYMENTS, [userId]);
   return result;
 };
 
-export default getPayments;
+export const createUserPayments = async (userId: number, paymentId: string) => {
+  const result = await sql(query.CREATE_USER_PAYMENTS, [userId, paymentId]);
+  return result;
+};
+
+export const createPayments = async (name: string) => {
+  const result = await sql(query.CREATE_PAYMENTS, [name]);
+  return result;
+};
+
+export const getPayments = async () => {
+  const result = await sql(query.READ_PAYMENTS, []);
+  return result;
+};
+
+export const getPaymentIdByName = async (name: string) => {
+  const result = await sql(query.GET_PAYMENT_ID_BY_NAME, [name]);
+  return result;
+};


### PR DESCRIPTION
### 📕 Issue Number

Linked #66 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- FE
   - 결재수단 관리 UI 수정
![image](https://user-images.githubusercontent.com/61405355/101807272-46727880-3b58-11eb-9eab-17b646fda5c4.png)

   - 입력 폼을 이용하여 값을 받아오고, 버튼에 클릭 이벤트로 axios 요청

- BE
   - POST 결재수단 API 함수 생성
![image](https://user-images.githubusercontent.com/61405355/101807145-1f1bab80-3b58-11eb-8737-cc9c1ce7cc6d.png)

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 버그 수정
- 리펙토링

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- payment에 추가하기 전에 payment에 똑같은 이름이 있다면 추가하지 않고 user_payment에만 추가해줄 수 있도록 구현하였습니다.

<br/><br/>