### PR TITLE
[콜리타임]-상단바 Z-index 문제 수정

### DIFF
--- a/client/src/components/organisms/TopNavBar/TopNavBar.tsx
+++ b/client/src/components/organisms/TopNavBar/TopNavBar.tsx
@@ -21,7 +21,7 @@ const FlexRowBox = styled.div<Props>`
   max-width: 1200px;
   height: 2rem;
   background-color: ${(props) => props.backgroundColor};
-  z-index: 1;
+  z-index: 10;
   position: fixed;
 `;
 


### PR DESCRIPTION
- 프로필 사진의 image 태그보다 아래에 나타나던 문제 수정

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 상단바가 img 태그에 가려지던 Z-index 문제 수정

![colly](https://user-images.githubusercontent.com/55074799/102004915-78522d80-3d58-11eb-8a40-f10b5f1bd9f4.gif)

<br/>

### 📘 작업 유형

- 버그 수정
