### PR TITLE
콜리타임 4주차 - 개인가계부 분석 내역 API response 수정

### DIFF
--- a/client/.env.sample
+++ b/client/.env.sample
@@ -1,0 +1,7 @@
+# GitHub OAuth 인증
+REACT_APP_GITHUB_CLIENT_ID = [GitHub APP Client ID]
+# Naver OAuth 인증
+REACT_APP_NAVER_CLIENT_ID = [Naver APP Client ID]
+REACT_APP_NAVER_CALLBACK_URL = [Naver App Callback URL]
+# API URL
+REACT_APP_BASE_URL = [API BASE URL]

--- a/client/src/components/atoms/graph/CircleGraph/CircleGraph.tsx
+++ b/client/src/components/atoms/graph/CircleGraph/CircleGraph.tsx
@@ -4,8 +4,8 @@ import { Doughnut } from 'react-chartjs-2';
 import myColor from '@theme/color';
 
 interface Props extends containerProps {
-  income: number;
-  expend: number;
+  income: number | null;
+  expend: number | null;
 }
 interface containerProps {
   size: number;

--- a/client/src/components/organisms/MyAccountInfoCard/MyAccountInfoCard.tsx
+++ b/client/src/components/organisms/MyAccountInfoCard/MyAccountInfoCard.tsx
@@ -65,7 +65,7 @@ const MyAccountInfoCard: React.FC<Props> = ({ link, info }: Props) => {
             <TwoByTwoChips data={info.category} />
           </ColumnFlexContainer>
           <ColumnFlexContainer width="25%" height="100%">
-            <CircleGraph size={6} income={Number(info.income)} expend={Number(info.expenditure)} />
+            <CircleGraph size={6} income={info.income} expend={info.expenditure} />
           </ColumnFlexContainer>
         </RowFlexContainer>
       </ColumnFlexContainer>

--- a/client/src/interfaces/accountbook.ts
+++ b/client/src/interfaces/accountbook.ts
@@ -14,6 +14,6 @@ export interface SocialBook {
 
 export interface PrivateBook {
   category: CategorySum[];
-  income: string | null;
-  expenditure: string | null;
+  income: number | null;
+  expenditure: number | null;
 }

--- a/client/src/views/MainPage.tsx
+++ b/client/src/views/MainPage.tsx
@@ -44,8 +44,8 @@ const SocialBooksBox = styled.div`
 
 const initPrivate = {
   category: [],
-  income: '0',
-  expenditure: '0',
+  income: 0,
+  expenditure: 0,
 };
 
 const MainPage: React.FC = () => {

--- a/server/src/privateBook/controller.ts
+++ b/server/src/privateBook/controller.ts
@@ -3,7 +3,7 @@ import * as response from '../utils/response';
 import 'dotenv/config';
 import * as Service from './service';
 import { TransactionList } from '../interface/transaction';
-import { getPastWeekList, getPastMonthList  } from '../utils/date';
+import { getPastWeekList, getPastMonthList } from '../utils/date';
 import { makeAnalysisData } from '../utils/makeAnalysisData';
 
 export const createTransaction = async (ctx: any) => {
@@ -82,14 +82,16 @@ export const getPastFiveWeekStatistic = async (ctx: any) => {
   response.success(ctx, result);
 };
 
-
 export const getMonthAnalysis = async (ctx: any) => {
   const userId = ctx.userData.uid;
   const bookId = await Service.getAccountBookId(userId);
   const category = await Service.getMonthCategoryData(bookId);
-  const income = await Service.getMonthIncomeData(bookId);
-  const expenditure = await Service.getMonthExpenditureData(bookId);
-  const data = makeAnalysisData(category, income.income, expenditure.expenditure);
+  const incomeResult = await Service.getMonthIncomeData(bookId);
+  const expendResult = await Service.getMonthExpenditureData(bookId);
+
+  const income = incomeResult ? Number(incomeResult) : 0;
+  const expend = expendResult ? Number(expendResult) : 0;
+  const data = makeAnalysisData(category, income, expend);
   response.success(ctx, data);
 };
 

--- a/server/src/privateBook/service.ts
+++ b/server/src/privateBook/service.ts
@@ -34,9 +34,10 @@ export const getWeeksIncome = async (bookId: number, startDate: string, endDate:
   const result = await sql(query.READ_PRIVATE_WEEKLY_STATISTICS_INCOME, [
     bookId,
     startDate,
-    `${endDate} 23:59:59`]);
+    `${endDate} 23:59:59`,
+  ]);
   return result[0]['SUM(amount)'];
-}
+};
 
 export const getMonthCategoryData = async (bookId: number) => {
   const result = await sql(query.READ_PRIVATE_MONTH_TRANSACTION, [bookId]);
@@ -45,19 +46,19 @@ export const getMonthCategoryData = async (bookId: number) => {
 
 export const getMonthIncomeData = async (bookId: number) => {
   const [result] = await sql(query.READ_PRIVATE_MONTH_INCOME, [bookId]);
-  return result;
+  return result.income;
 };
 
 export const getMonthExpenditureData = async (bookId: number) => {
   const [result] = await sql(query.READ_PRIVATE_MONTH_EXPENDITURE, [bookId]);
-  return result;
+  return result.expenditure;
 };
 
 export const getMonthlyStatisticsExpend = async (
   bookId: number,
   startDate: string,
   endDate: string,
-  ) => {
+) => {
   const result = await sql(query.READ_PRIVATE_MONTHLY_STATISTICS_EXPEND, [
     bookId,
     startDate,


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- client에 `.env.sample` 파일을 추가해주었습니다.
- 개인 가계부 분석 정보 조회의 경우 지출합과 수입합을 string으로 return 하였는데 이를 number 형태로 변경하였으며 결과값이 없는경우 null 대신 0을 반환하도록 하였습니다.
- 변경된 API에 맞춰 client의 코드가 정상동작하도록 변경해주었습니다.

<br/>

### 📘 작업 유형

- 버그 수정
- 리펙토링

<br/>