### PR TITLE
BE-feat-accountbook-accept 소셜 가계부 초대 목록조회, 승인/거절, 초대취소 API 개발

### DIFF
--- a/server/src/model/query/socialBookQuery.ts
+++ b/server/src/model/query/socialBookQuery.ts
@@ -81,6 +81,11 @@ const socialBookQuery = {
     LEFT OUTER JOIN social_accountbook book ON invitation.accountbook_id = book.id
     WHERE user_id = ? AND state = 1;`,
   UPDATE_SOCIAL_INVITATION: `UPDATE social_accountbook_users SET state = ? WHERE user_id = ? AND id = ? AND state = 1;`,
+  GET_SOCIAL_INVITATION_MASTER: `
+    SELECT master_id as id FROM social_accountbook_users users
+    LEFT OUTER JOIN social_accountbook book ON book.id = users.accountbook_id
+    WHERE users.id = ?`,
+  DELETE_SOCIAL_INVITATION: `DELETE FROM social_accountbook_users WHERE id = ? AND state = 1;`,
 };
 
 export default socialBookQuery;

--- a/server/src/model/query/socialBookQuery.ts
+++ b/server/src/model/query/socialBookQuery.ts
@@ -80,6 +80,7 @@ const socialBookQuery = {
     FROM social_accountbook_users invitation
     LEFT OUTER JOIN social_accountbook book ON invitation.accountbook_id = book.id
     WHERE user_id = ? AND state = 1;`,
+  UPDATE_SOCIAL_INVITATION: `UPDATE social_accountbook_users SET state = ? WHERE user_id = ? AND id = ? AND state = 1;`,
 };
 
 export default socialBookQuery;

--- a/server/src/model/query/socialBookQuery.ts
+++ b/server/src/model/query/socialBookQuery.ts
@@ -74,6 +74,12 @@ const socialBookQuery = {
     LEFT OUTER JOIN payment as py ON py.id = st.payment_id 
     WHERE st.accountbook_id = ? AND year(st.date) = ? AND month(st.date) = ? ORDER BY st.date`,
   UPDATE_SOCIAL_TRANSACTION: `UPDATE social_transaction SET category_id = ?, payment_id = ?, date = ?, title = ?, amount = ? WHERE id = ?`,
+  GET_SOCIAL_INVITATION: `
+    SELECT invitation.id, invited_at, name,
+    (SELECT name FROM users WHERE master_id = users.id) as master
+    FROM social_accountbook_users invitation
+    LEFT OUTER JOIN social_accountbook book ON invitation.accountbook_id = book.id
+    WHERE user_id = ? AND state = 1;`,
 };
 
 export default socialBookQuery;

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -191,3 +191,27 @@ export const patchInvitation = async (ctx: any) => {
 
   response.success(ctx, id);
 };
+
+export const deleteInvitation = async (ctx: any) => {
+  const userId = ctx.userData.uid;
+  const { id } = ctx.params;
+  const master = await Service.getInvitationMasterId(id);
+
+  if (master === undefined) {
+    response.fail(ctx, 403, message.NO_SOCIAL_INVITATION);
+    return;
+  }
+
+  if (master.id !== userId) {
+    response.fail(ctx, 403, message.NO_SOCIAL_AUTHORIZED);
+    return;
+  }
+
+  const result = await Service.deleteInvitation(id);
+  if (result.affectedRows === 0) {
+    response.fail(ctx, 403, message.NO_INVITATION_WAITING_STATE);
+    return;
+  }
+
+  response.success(ctx, id);
+};

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -181,3 +181,13 @@ export const getInvitation = async (ctx: any) => {
 
   response.success(ctx, result);
 };
+
+export const patchInvitation = async (ctx: any) => {
+  const userId = ctx.userData.uid;
+  const { id } = ctx.params;
+  const { accept } = ctx.request.body;
+
+  await Service.patchInvitation(userId, id, accept);
+
+  response.success(ctx, id);
+};

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -173,3 +173,11 @@ export const updateTransaction = async (ctx: any) => {
   await Service.updateTransaction(transaction);
   response.success(ctx, id);
 };
+
+export const getInvitation = async (ctx: any) => {
+  const userId = ctx.userData.uid;
+
+  const result = await Service.getInvitation(userId);
+
+  response.success(ctx, result);
+};

--- a/server/src/socialBook/router.ts
+++ b/server/src/socialBook/router.ts
@@ -26,4 +26,6 @@ router.put('/transaction', Controller.updateTransaction);
 
 router.get('/invitation', Controller.getInvitation);
 
+router.patch('/invitation/:id', Controller.patchInvitation);
+
 export default router;

--- a/server/src/socialBook/router.ts
+++ b/server/src/socialBook/router.ts
@@ -24,4 +24,6 @@ router.post('/createAccountbook', Controller.createAccountbook);
 
 router.put('/transaction', Controller.updateTransaction);
 
+router.get('/invitation', Controller.getInvitation);
+
 export default router;

--- a/server/src/socialBook/router.ts
+++ b/server/src/socialBook/router.ts
@@ -28,4 +28,6 @@ router.get('/invitation', Controller.getInvitation);
 
 router.patch('/invitation/:id', Controller.patchInvitation);
 
+router.delete('/invitation/:id', Controller.deleteInvitation);
+
 export default router;

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -147,3 +147,8 @@ export const updateTransaction = async (transaction: (string | number)[]) => {
   const result = await sql(query.UPDATE_SOCIAL_TRANSACTION, transaction);
   return result;
 };
+
+export const getInvitation = async (userId: string) => {
+  const result = await sql(query.GET_SOCIAL_INVITATION, [userId]);
+  return result;
+};

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -1,8 +1,15 @@
+/* eslint-disable no-unused-vars */
 import 'dotenv/config';
 import sql from '../model/db';
 import query from '../model/query';
 import { UserImage, SocialInfo, SocialBookId } from '../interface/social';
 import { getCategoryPercentData } from '../utils/accountbook';
+
+// eslint-disable-next-line no-shadow
+enum INVITATION {
+  REJECT = -2,
+  ACCEPT = 2,
+}
 
 export const getSocialBooks = async (userId: number) => {
   const socialBookList = await sql(query.READ_SOCIAL_BOOK_LIST, [userId]);
@@ -150,5 +157,16 @@ export const updateTransaction = async (transaction: (string | number)[]) => {
 
 export const getInvitation = async (userId: string) => {
   const result = await sql(query.GET_SOCIAL_INVITATION, [userId]);
+  return result;
+};
+
+export const patchInvitation = async (userId: string, id: number, accept: boolean) => {
+  let state;
+  if (accept) {
+    state = INVITATION.ACCEPT;
+  } else {
+    state = INVITATION.REJECT;
+  }
+  const result = await sql(query.UPDATE_SOCIAL_INVITATION, [state, userId, id]);
   return result;
 };

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -170,3 +170,14 @@ export const patchInvitation = async (userId: string, id: number, accept: boolea
   const result = await sql(query.UPDATE_SOCIAL_INVITATION, [state, userId, id]);
   return result;
 };
+
+export const getInvitationMasterId = async (id: string) => {
+  const [result] = await sql(query.GET_SOCIAL_INVITATION_MASTER, [id]);
+  return result;
+};
+
+export const deleteInvitation = async (id: string) => {
+  console.log('in');
+  const result = await sql(query.DELETE_SOCIAL_INVITATION, [id]);
+  return result;
+};

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -177,7 +177,6 @@ export const getInvitationMasterId = async (id: string) => {
 };
 
 export const deleteInvitation = async (id: string) => {
-  console.log('in');
   const result = await sql(query.DELETE_SOCIAL_INVITATION, [id]);
   return result;
 };

--- a/server/src/utils/message.ts
+++ b/server/src/utils/message.ts
@@ -1,5 +1,7 @@
 const errorMessage = {
   NO_SOCIAL_AUTHORIZED: `You are not authorized to this account book`,
+  NO_SOCIAL_INVITATION: `You have sent an invalid invitation request.`,
+  NO_INVITATION_WAITING_STATE: `The request is not a request for a pending invitation.`,
 };
 
 export default errorMessage;


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 유저의 소셜 가계부 대기 요청 목록을 반환하는 API 개발
> [GET] http://localhost:3000/api/social/invitation

200 response
```json
{
    "status": "success",
    "data": [
        {
            "id": 2,
            "invited_at": "2020-12-13T13:15:38.000Z",
            "name": "클리어",
            "master": "이지우"
        },
        {
            "id": 8,
            "invited_at": "2020-12-13T13:15:38.000Z",
            "name": "밥.좋.아",
            "master": "Je Koo Park"
        }
    ]
}
```
- 소셜 가계부 요청을 승인/거절하는 API 개발
> [PATCH] http://localhost:3000/api/social/invitation/:id

body
```json
{
    "accept": true
}
```
200 response
```
{
    "status": "success",
    "data": "2"
}
```

- 초대 요청 중 아직 사용자가 승인/거절하지 않은 초대를 취소하는 API 개발 
> [DELETE] http://localhost:3000/api/social/invitation/:id

200 response
```json
{
    "status": "success",
    "data": "15"
}
```
403 response - 존재하지 않는 초대에 대한 요청
```json
{
    "status": "fail",
    "data": "You have sent an invalid invitation request."
}
```
403 response - master 권한이 없는데 초대 삭제 요청
```json
{
    "status": "fail",
    "data": "You are not authorized to this account book"
}
```
403 response - 대기 상태가 아닌 초대에 대한 요청
```json
{
    "status": "fail",
    "data": "The request is not a request for a pending invitation."
}
```
<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>