### PR TITLE
BE-statistic trend graph API

### DIFF
--- a/server/.env.sample
+++ b/server/.env.sample
@@ -20,5 +20,5 @@ JWT_SECRET = [JWT SECRET]
 JWT_EXPIRE = [JWT 기간설정]
 # default image 
 DEFAULT_IMG = [DEFAULT_IMG]
-# 인증 성공
-LOGIN_SUCCESS_URL = [인증성공 리다이렉트 URL]
+# 인증 실패
+LOGIN_URL = [인증실패 리다이렉트 URL]

--- a/server/src/model/query/privateBookQuery.ts
+++ b/server/src/model/query/privateBookQuery.ts
@@ -47,6 +47,18 @@ const privateBookQuery = {
   READ_PRIVATE_MONTHLY_STATISTICS_INCOME: `
     SELECT SUM(amount) FROM private_transaction 
     WHERE accountbook_id = ? AND date >= ? AND date < ? AND payment_id IS NULL`,
+  READ_PRIVATE_TREND_INCOME: `
+    SELECT SUM(amount) as money, date_format(date, '%d') as day
+    FROM private_transaction
+    WHERE accountbook_id = ? AND payment_id IS NULL
+    AND year(date) = ? AND month(date) = ?
+    GROUP BY day ORDER BY day`,
+  READ_PRIVATE_TREND_EXPENDITURE: `
+    SELECT SUM(amount) as money, date_format(date, '%d') as day
+    FROM private_transaction
+    WHERE accountbook_id = ? AND payment_id IS NOT NULL
+    AND year(date) = ? AND month(date) = ?
+    GROUP BY day ORDER BY day`,
   UPDATE_PRIVATE_TRANSACTION: `UPDATE private_transaction SET category_id = ?, payment_id = ?, date = ?, title = ?, amount = ? WHERE id = ?`,
   DELETE_PRIVATE_TRANSACTION: `DELETE FROM private_transaction WHERE id = ?`,
 };

--- a/server/src/privateBook/controller.ts
+++ b/server/src/privateBook/controller.ts
@@ -115,6 +115,22 @@ export const getPastFourMonthStatistics = async (ctx: any) => {
   response.success(ctx, result);
 };
 
+export const getTrendStatisticIncome = async (ctx: any) => {
+  const { year, month } = ctx.params;
+  const userId = ctx.userData.uid;
+  const accountbookId = await Service.getAccountBookId(userId);
+  const result = await Service.getTrendIncome(accountbookId, year, month);
+  response.success(ctx, result);
+};
+
+export const getTrendStatisticExpenditure = async (ctx: any) => {
+  const { year, month } = ctx.params;
+  const userId = ctx.userData.uid;
+  const accountbookId = await Service.getAccountBookId(userId);
+  const result = await Service.getTrendExpenditure(accountbookId, year, month);
+  response.success(ctx, result);
+};
+
 export const updateTransaction = async (ctx: any) => {
   const { id, categoryId, paymentId, date, title, amount } = ctx.request.body;
   const transaction = [categoryId, paymentId, date, title, amount, id];

--- a/server/src/privateBook/router.ts
+++ b/server/src/privateBook/router.ts
@@ -16,6 +16,10 @@ router.get('/analysis', Controller.getMonthAnalysis);
 
 router.get('/statistics/monthly/', Controller.getPastFourMonthStatistics);
 
+router.get('/statistic/trend/income/:year/:month', Controller.getTrendStatisticIncome);
+
+router.get('/statistic/trend/expenditure/:year/:month', Controller.getTrendStatisticExpenditure);
+
 router.put('/transaction', Controller.updateTransaction);
 
 export default router;

--- a/server/src/privateBook/service.ts
+++ b/server/src/privateBook/service.ts
@@ -89,6 +89,16 @@ export const getMonthlyStatisticsIncome = async (
   return result[0]['SUM(amount)'];
 };
 
+export const getTrendIncome = async (bookId: number, year: number, month: number) => {
+  const result = await sql(query.READ_PRIVATE_TREND_INCOME, [bookId, year, month]);
+  return result;
+};
+
+export const getTrendExpenditure = async (bookId: number, year: number, month: number) => {
+  const result = await sql(query.READ_PRIVATE_TREND_EXPENDITURE, [bookId, year, month]);
+  return result;
+};
+
 export const updateTransaction = async (transaction: (string | number)[]) => {
   const result = await sql(query.UPDATE_PRIVATE_TRANSACTION, transaction);
   return result;


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 쿼리문 with @do02reen24 
- 통계 월간 일별 추이 그래프 API 구현
-> 일간 총합 지출/수입을 계산하여 리턴

`api/private/statistic/trend/income/:year/:month`,
`api/private/statistic/trend/expenditure/:year/:month`,

Response 
```json=
    {
    "status": "success",
    "data": [
        {
            "money": "898140",
            "day": "08"
        },
        {
            "money": "142000",
            "day": "15"
        },
        {
            "money": "3323010",
            "day": "18"
        },
        {
            "money": "1000000",
            "day": "27"
        }
    ]
}
```



<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 소셜 부분 월요일에 추가하겠습니다!