### PR TITLE
BE-feat-소셜가계부 초대 API 구현 및 유저 목록 API 구현

### DIFF
--- a/server/src/model/query/userQuery.ts
+++ b/server/src/model/query/userQuery.ts
@@ -3,6 +3,7 @@ const userQuery = {
   READ_USER_INFO: 'SELECT name, picture FROM users WHERE id = ?',
   CREATE_USER:
     'INSERT INTO users (pid, email, name, region, picture, color, is_sunday, oauth_origin) VALUES(?,?,?,?,?,?,?,?)',
+  READ_USER_BY_NAME: 'SELECT id, email, name, picture FROM users WHERE name LIKE ?',
 };
 
 export default userQuery;

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -173,3 +173,9 @@ export const updateTransaction = async (ctx: any) => {
   await Service.updateTransaction(transaction);
   response.success(ctx, id);
 };
+
+export const inviteAccountbookUser = async (ctx: any) => {
+  const { userId, accountbookId } = ctx.request.body;
+  const result = await Service.inviteAccountbookUser(userId, accountbookId);
+  response.success(ctx, result);
+};

--- a/server/src/socialBook/router.ts
+++ b/server/src/socialBook/router.ts
@@ -24,4 +24,6 @@ router.post('/createAccountbook', Controller.createAccountbook);
 
 router.put('/transaction', Controller.updateTransaction);
 
+router.post('/invitation', Controller.inviteAccountbookUser);
+
 export default router;

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -147,3 +147,9 @@ export const updateTransaction = async (transaction: (string | number)[]) => {
   const result = await sql(query.UPDATE_SOCIAL_TRANSACTION, transaction);
   return result;
 };
+
+export const inviteAccountbookUser = async (userId: Number, accountbookId: Number) => {
+  const result = await sql(query.CREATE_SOCIAL_ACCOUNTBOOK_USERS, [userId, accountbookId, 1]);
+
+  return result.insertId;
+};

--- a/server/src/user/controller.ts
+++ b/server/src/user/controller.ts
@@ -9,4 +9,8 @@ export const getUserInfo = async (ctx: Context) => {
   response.success(ctx, result);
 };
 
-export default getUserInfo;
+export const getUserByName = async (ctx: Context) => {
+  const { name } = ctx.params;
+  const result = await Service.getUserByName(name);
+  response.success(ctx, result);
+};

--- a/server/src/user/router.ts
+++ b/server/src/user/router.ts
@@ -6,4 +6,6 @@ const router = new Router();
 
 router.get('/info', Controller.getUserInfo);
 
+router.get('/list/:name', Controller.getUserByName);
+
 export default router;

--- a/server/src/user/service.ts
+++ b/server/src/user/service.ts
@@ -7,4 +7,7 @@ export const getUserInfo = async (userId: number) => {
   return result;
 };
 
-export default getUserInfo;
+export const getUserByName = async (name: string) => {
+  const result = await sql(query.READ_USER_BY_NAME, [`%${name}%`]);
+  return result;
+};


### PR DESCRIPTION
### 📕 Issue Number

related Issue #105 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

### User 목록 API

- 주소 : `/api/user/list/:name`

- Like %?% 조합으로 입력된 name을 포함하는 문자열을 찾도록 구현

- response 
```JSON
# name='도' 검색시 결과

{
    "status": "success",
    "data": [
        {
            "id": 34,
            "email": "dykim0224@naver.com",
            "name": "김도연",
            "picture": null
        }
    ]
}
```

### Social 가계부 초대 API 


- unique Key 지정으로, 소셜유저 테이블속 userId - accountbookId 조합의 유일성을 보증하도록 변경 하였습니다

- 주소 : `/api/social/invitation`

- request Body
```JSON
{
    "userId": <number>,
    "accountbookId": <number>
}
```

- response
```JSON
{
    "status": "success",
    "data": <INSERT PK>
}
```

<br/>

### 📘 작업 유형

- 신규 기능 추가


<br/>