### PR TITLE
BE-feat-trendgraph social API

### DIFF
--- a/server/src/model/query/socialBookQuery.ts
+++ b/server/src/model/query/socialBookQuery.ts
@@ -87,6 +87,18 @@ const socialBookQuery = {
     LEFT OUTER JOIN social_accountbook book ON book.id = users.accountbook_id
     WHERE users.id = ?`,
   DELETE_SOCIAL_INVITATION: `DELETE FROM social_accountbook_users WHERE id = ? AND state = 1;`,
+  READ_SOCIAL_TREND_INCOME: `
+    SELECT SUM(amount) as money, date_format(date, '%d') as day
+    FROM social_transaction
+    WHERE accountbook_id = ? AND payment_id IS NULL
+    AND year(date) = ? AND month(date) = ?
+    GROUP BY day ORDER BY day`,
+  READ_SOCIAL_TREND_EXPENDITURE: `
+    SELECT SUM(amount) as money, date_format(date, '%d') as day
+    FROM social_transaction
+    WHERE accountbook_id = ? AND payment_id IS NOT NULL
+    AND year(date) = ? AND month(date) = ?
+    GROUP BY day ORDER BY day`,
 };
 
 export default socialBookQuery;

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -229,13 +229,13 @@ export const deleteInvitation = async (ctx: any) => {
 };
 
 export const getTrendStatisticIncome = async (ctx: any) => {
-  const { accountbookId, year, month } = ctx.params;
-  const result = await Service.getTrendIncome(accountbookId, year, month);
+  const { bookId, year, month } = ctx.params;
+  const result = await Service.getTrendIncome(bookId, year, month);
   response.success(ctx, result);
 };
 
 export const getTrendStatisticExpenditure = async (ctx: any) => {
-  const { accountbookId, year, month } = ctx.params;
-  const result = await Service.getTrendExpenditure(accountbookId, year, month);
+  const { bookId, year, month } = ctx.params;
+  const result = await Service.getTrendExpenditure(bookId, year, month);
   response.success(ctx, result);
 };

--- a/server/src/socialBook/controller.ts
+++ b/server/src/socialBook/controller.ts
@@ -227,3 +227,15 @@ export const deleteInvitation = async (ctx: any) => {
 
   response.success(ctx, id);
 };
+
+export const getTrendStatisticIncome = async (ctx: any) => {
+  const { accountbookId, year, month } = ctx.params;
+  const result = await Service.getTrendIncome(accountbookId, year, month);
+  response.success(ctx, result);
+};
+
+export const getTrendStatisticExpenditure = async (ctx: any) => {
+  const { accountbookId, year, month } = ctx.params;
+  const result = await Service.getTrendExpenditure(accountbookId, year, month);
+  response.success(ctx, result);
+};

--- a/server/src/socialBook/router.ts
+++ b/server/src/socialBook/router.ts
@@ -34,4 +34,11 @@ router.patch('/invitation/:id', Controller.patchInvitation);
 
 router.delete('/invitation/:id', Controller.deleteInvitation);
 
+router.get('/statistic/trend/income/:bookId/:year/:month', Controller.getTrendStatisticIncome);
+
+router.get(
+  '/statistic/trend/expenditure/:bookId/:year/:month',
+  Controller.getTrendStatisticExpenditure,
+);
+
 export default router;

--- a/server/src/socialBook/service.ts
+++ b/server/src/socialBook/service.ts
@@ -191,3 +191,13 @@ export const deleteInvitation = async (id: string) => {
   const result = await sql(query.DELETE_SOCIAL_INVITATION, [id]);
   return result;
 };
+
+export const getTrendIncome = async (bookId: number, year: number, month: number) => {
+  const result = await sql(query.READ_SOCIAL_TREND_INCOME, [bookId, year, month]);
+  return result;
+};
+
+export const getTrendExpenditure = async (bookId: number, year: number, month: number) => {
+  const result = await sql(query.READ_SOCIAL_TREND_EXPENDITURE, [bookId, year, month]);
+  return result;
+};


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 쿼리문 
- 통계 월간 일별 추이 그래프 API 구현
-> 일간 총합 지출/수입을 계산하여 리턴

`api/social/statistic/trend/income/:bookId/:year/:month`,
`api/social/statistic/trend/expenditure/:bookId/:year/:month`,

Response 
```json=
    {
    "status": "success",
    "data": [
        {
            "money": "95190",
            "day": "02"
        },
        {
            "money": "1500",
            "day": "07"
        },
        {
            "money": "40000",
            "day": "09"
        }
    ]
}
```



<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>
