### PR TITLE
FE-feat-invitation 소셜 가계부 승인/거절 페이지 완성

### DIFF
--- a/client/src/components/molecules/InvitationCard/InvitationCard.stories.tsx
+++ b/client/src/components/molecules/InvitationCard/InvitationCard.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import InvitationCard from './InvitationCard';
 
 interface Props {
+  id: number;
   master: string;
   name: string;
   time: string;
@@ -11,6 +12,7 @@ export default {
   title: 'molecules/InvitationCard',
   component: InvitationCard,
   argTypes: {
+    id: { control: 'number' },
     master: { control: 'text' },
     name: { control: 'text' },
     time: { control: 'text' },
@@ -18,9 +20,11 @@ export default {
 };
 
 export const invitationCard = ({ ...args }: Props): JSX.Element => {
-  const callback = () => {
+  const callback = (id: number, isAccept: boolean) => {
+    console.log(id, isAccept);
     return true;
   };
+
   return <InvitationCard {...args} callback={callback} />;
 };
 
@@ -29,6 +33,7 @@ invitationCard.story = {
 };
 
 invitationCard.args = {
+  id: 1,
   master: '김도연',
   name: '부스트 동아리',
   time: '2020-11-10 02:12:00',

--- a/client/src/components/molecules/InvitationCard/InvitationCard.tsx
+++ b/client/src/components/molecules/InvitationCard/InvitationCard.tsx
@@ -9,10 +9,11 @@ import color from '@theme/color';
 import { getPastTimeString } from '@utils/date';
 
 interface Props {
+  id: number;
   master: string;
   name: string;
   time: string;
-  callback: (isAccept: boolean) => void;
+  callback: (id: number, isAccept: boolean) => void;
 }
 
 const Container = styled.div`
@@ -24,7 +25,7 @@ const Container = styled.div`
   box-sizing: border-box;
 `;
 
-const InvitationCard: React.FC<Props> = ({ master, name, time, callback }: Props) => {
+const InvitationCard: React.FC<Props> = ({ id, master, name, time, callback }: Props) => {
   return (
     <Container>
       <RowContainer justifyContent="flex-end">
@@ -37,9 +38,9 @@ const InvitationCard: React.FC<Props> = ({ master, name, time, callback }: Props
         </Text>
       </RowContainer>
       <RowContainer justifyContent="space-around">
-        <Button onClick={() => callback(true)}>수락</Button>
+        <Button onClick={() => callback(id, true)}>수락</Button>
         <Button
-          onClick={() => callback(false)}
+          onClick={() => callback(id, false)}
           backgroundColor={color.primary.lightGray}
           color={color.primary.black}
         >

--- a/client/src/components/organisms/InvitationManagementModal/InvitationManagementModal.stories.tsx
+++ b/client/src/components/organisms/InvitationManagementModal/InvitationManagementModal.stories.tsx
@@ -7,34 +7,7 @@ export default {
 };
 
 export const accountBookAcceptModal = (): JSX.Element => {
-  const data = [
-    {
-      id: 2,
-      time: '2020-12-13T18:15:38.000Z',
-      name: '클리어',
-      master: '김도연',
-    },
-    {
-      id: 4,
-      time: '2020-12-10T13:15:38.000Z',
-      name: '밥.좋.아',
-      master: 'Je Koo Park',
-    },
-    {
-      id: 8,
-      time: '2020-12-01T13:24:38.000Z',
-      name: '링가링가링',
-      master: '이지우',
-    },
-    {
-      id: 5,
-      time: '2020-11-13T13:15:38.000Z',
-      name: '오므라이스',
-      master: '장준영',
-    },
-  ];
-
-  return <InvitationManagementModal data={data} />;
+  return <InvitationManagementModal />;
 };
 
 accountBookAcceptModal.story = {

--- a/client/src/components/organisms/InvitationManagementModal/InvitationManagementModal.tsx
+++ b/client/src/components/organisms/InvitationManagementModal/InvitationManagementModal.tsx
@@ -3,7 +3,7 @@ import Modal from '@molecules/Modal';
 import Card from '@molecules/InvitationCard';
 import styled from 'styled-components';
 import { Invitation } from '@interfaces/accountbook';
-import { getAxiosData } from '@utils/axios';
+import { getAxiosData, patchAxios } from '@utils/axios';
 import * as API from '@utils/api';
 
 const Container = styled.div`
@@ -28,10 +28,12 @@ const InvitationManagementModal: React.FC = () => {
     getInvitation();
   }, []);
 
-  const postInvitation = (id: number, isAccept: boolean) => {
-    console.log(id, isAccept);
+  const postInvitation = async (id: number, isAccept: boolean) => {
+    const data = {
+      accept: isAccept,
+    };
+    await patchAxios(API.PATCH_INVITATION(id), data);
     getInvitation();
-    return true;
   };
 
   const invitationCards = () =>

--- a/client/src/components/organisms/InvitationManagementModal/InvitationManagementModal.tsx
+++ b/client/src/components/organisms/InvitationManagementModal/InvitationManagementModal.tsx
@@ -1,12 +1,10 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Modal from '@molecules/Modal';
 import Card from '@molecules/InvitationCard';
 import styled from 'styled-components';
 import { Invitation } from '@interfaces/accountbook';
-
-interface Props {
-  data: Invitation[];
-}
+import { getAxiosData } from '@utils/axios';
+import * as API from '@utils/api';
 
 const Container = styled.div`
   overflow: scroll;
@@ -16,21 +14,34 @@ const Container = styled.div`
   width: 100%;
 `;
 
-const InvitationManagementModal: React.FC<Props> = ({ data }: Props) => {
+const InvitationManagementModal: React.FC = () => {
   const title = '가계부 승인/거절';
 
-  const callback = () => {
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+
+  const getInvitation = async () => {
+    const result = await getAxiosData(API.GET_INVITATION);
+    setInvitations(result.data);
+  };
+
+  useEffect(() => {
+    getInvitation();
+  }, []);
+
+  const postInvitation = (id: number, isAccept: boolean) => {
+    console.log(id, isAccept);
+    getInvitation();
     return true;
   };
 
-  const invitationCards = (invitations: Invitation[]) =>
+  const invitationCards = () =>
     invitations.map((invitation) => (
-      <Card key={invitation.id} callback={callback} {...invitation} />
+      <Card key={invitation.id} callback={postInvitation} {...invitation} />
     ));
 
   return (
     <Modal title={title}>
-      <Container>{invitationCards(data)}</Container>
+      <Container>{invitationCards()}</Container>
     </Modal>
   );
 };

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -54,3 +54,6 @@ export const DELETE_PAYMENT = (name: number): string =>
   `${process.env.REACT_APP_BASE_URL}/api/payment/${name}`;
 
 export const GET_INVITATION = `${process.env.REACT_APP_BASE_URL}/api/social/invitation`;
+
+export const PATCH_INVITATION = (id: number): string =>
+  `${process.env.REACT_APP_BASE_URL}/api/social/invitation/${id}`;

--- a/client/src/utils/axios.ts
+++ b/client/src/utils/axios.ts
@@ -36,6 +36,12 @@ export const putAxios = async (api: string, data: any): Promise<AxiosResponse<an
   return result;
 };
 
+export const patchAxios = async (api: string, data: any): Promise<AxiosResponse<any>> => {
+  const config = getConfig();
+  const result = await axios.patch(api, data, config);
+  return result;
+};
+
 export const deleteAxios = async (api: string): Promise<AxiosResponse<any>> => {
   const config = getConfig();
   const result = await axios.delete(api, config);

--- a/client/src/utils/date.ts
+++ b/client/src/utils/date.ts
@@ -83,7 +83,7 @@ export const getPastTimeString = (date: string): string => {
   const diffSecond = (currentTime.getTime() - createTime.getTime()) / 1000;
 
   if (diffSecond < MIN) {
-    return `${diffSecond} seconds ago...`;
+    return `${Math.round(diffSecond)} seconds ago...`;
   }
 
   if (diffSecond < HOUR) {

--- a/client/src/views/MyPage.tsx
+++ b/client/src/views/MyPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import CenterContent from '@molecules/CenterContent';
 import BeeBackground from '@organisms/BeeBackground';
 import TopNavBar from '@organisms/TopNavBar';
@@ -9,25 +9,11 @@ import CreditCardEditModal from '@organisms/CreditCardEditModal';
 import UserInfoSettingModal from '@organisms/UserInfoSettingModal';
 import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
-import { Invitation } from '@interfaces/accountbook';
-import { getAxiosData } from '@utils/axios';
-import * as API from '@utils/api';
 
 const MyPage: React.FC = () => {
   const modalView = useSelector((state: RootState) => state.modal.view);
   const userName = useSelector((state: RootState) => state.user.name);
   const userImage = useSelector((state: RootState) => state.user.image);
-
-  const [invitations, setInvitations] = useState<Invitation[]>([]);
-
-  const getInvitation = async () => {
-    const result = await getAxiosData(API.GET_INVITATION);
-    setInvitations(result.data);
-  };
-
-  useEffect(() => {
-    getInvitation();
-  }, []);
 
   return (
     <>
@@ -37,7 +23,7 @@ const MyPage: React.FC = () => {
         <MyPageUserMenu name={userName} profile={userImage} />
         <MyPageMenu />
       </CenterContent>
-      {modalView === 'AccountBookAccept' && <InvitationManagementModal data={invitations} />}
+      {modalView === 'AccountBookAccept' && <InvitationManagementModal />}
       {modalView === 'CreditCardEdit' && <CreditCardEditModal />}
       {modalView === 'UserInfoSetting' && <UserInfoSettingModal />}
     </>

--- a/server/src/model/query/socialBookQuery.ts
+++ b/server/src/model/query/socialBookQuery.ts
@@ -66,7 +66,7 @@ const socialBookQuery = {
   CREATE_SOCIAL_ACCOUNTBOOK:
     'INSERT INTO social_accountbook (master_id, name, description, color) VALUES(?,?,?,?)',
   CREATE_SOCIAL_ACCOUNTBOOK_USERS:
-    'INSERT INTO social_accountbook_users (user_id, accountbook_id, state) VALUES(?,?,?)',
+    'INSERT INTO social_accountbook_users (user_id, accountbook_id, state, invited_at) VALUES(?,?,?, NOW())',
   GET_SOCIAL_TRANSACTIONLIST: `
     SELECT st.id, st.date, py.name, ct.name as category, st.title, st.amount, at.name as assortment FROM social_transaction as st 
     JOIN category as ct ON st.category_id = ct.id 


### PR DESCRIPTION
### 📕 Issue Number

Close #165 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- CreditEditModal 과 통일성을 유지하기 위해 InvitationModal의 정보를 Mypage에서 넘겨주지 않고 모달 호출시 불러오도록 수정하였습니다.
- 사용자가 승인/거절 버튼 클릭시 각 버튼에 맞는 동작을 수행하도록 개발하였습니다. (선택 즉시 목록에서 사라지도록 하였습니다.)

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- social_accountbook_users 테이블 설정 변경
    - 사용자가 승인/거절을 할 때 update query를 보냈는데 `invited_at`의 시간이 업데이트 되는 문제가 존재했습니다. 이를 해결하기 위해 database에서 default 설정으로 현재시간이 지정되어있던 것을 제거해주었습니다.
    - `accepted_at`의 이름이 모호하다고 생각하여 `updated_at`으로 변경하였으며 insert, update시 자동업데이트 되도록하였습니다.
    - 변경된 설정에 맞춰 기존 백엔드 호출 쿼리문을 변경해주었습니다.

<br/><br/>