### PR TITLE
FE-feat-pie-chart 파이 차트 구현

### DIFF
--- a/client/src/components/atoms/button/CircleIconButton/CircleIconButton.tsx
+++ b/client/src/components/atoms/button/CircleIconButton/CircleIconButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import myColor from '@theme/color';
 
 interface Props extends ColorProps {
   onClick: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
@@ -22,7 +23,7 @@ const IconBackground = styled.div<ColorProps>`
 `;
 
 const CircleIconButton = styled.button`
-  background-color: white;
+  background-color: ${myColor.primary.white};
   border: 0;
 `;
 

--- a/client/src/components/atoms/button/IconButton/IconButton.tsx
+++ b/client/src/components/atoms/button/IconButton/IconButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import myColor from '@theme/color';
 
 interface Props {
   children: React.ReactChild;
@@ -20,7 +21,7 @@ const Button = styled.button`
   width: 50px;
   height: 50px;
   border: none;
-  background-color: white;
+  background-color: ${myColor.primary.white};
 `;
 
 const IconButton: React.FC<Props> = ({ onClick, children }: Props) => {

--- a/client/src/components/atoms/button/OAuthButton/OAuthButton.tsx
+++ b/client/src/components/atoms/button/OAuthButton/OAuthButton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import Naver from '@svg/naver-logo.svg';
 import GitHub from '@svg/github-logo.svg';
+import myColor from '@theme/color';
 
 interface Props extends ColorProps {
   link: string;
@@ -26,7 +27,7 @@ const OAuthButton = styled.a`
 `;
 
 const OAuthIcon = styled.img`
-  background-color: white;
+  background-color: ${myColor.primary.white};
   height: 100%;
 `;
 
@@ -37,7 +38,7 @@ const OAuthName = styled.div<ColorProps>`
   align-items: center;
   height: 100%;
   background-color: ${(props) => props.backgroundColor};
-  color: white;
+  color: ${myColor.primary.white};
   border-radius: 5px;
   font-size: 18px;
   @media (max-width: 530px) {

--- a/client/src/components/atoms/button/RoundButton/RoundButton.tsx
+++ b/client/src/components/atoms/button/RoundButton/RoundButton.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const defaultProps = {
   backgroundColor: myColor.primary.accent,
-  color: 'white',
+  color: myColor.primary.white,
   onClick: undefined,
 };
 

--- a/client/src/components/atoms/button/RoundLongButton/RoundLongButton.tsx
+++ b/client/src/components/atoms/button/RoundLongButton/RoundLongButton.tsx
@@ -13,7 +13,7 @@ interface Props {
 const defaultProps = {
   backgroundColor: myColor.primary.accent,
   isSubmit: false,
-  color: 'white',
+  color: myColor.primary.white,
   onClick: undefined,
 };
 

--- a/client/src/components/atoms/button/RoundShortButton/RoundShortButton.tsx
+++ b/client/src/components/atoms/button/RoundShortButton/RoundShortButton.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const defaultProps = {
   backgroundColor: myColor.primary.accent,
-  color: 'white',
+  color: myColor.primary.white,
   border: 'solid 1px',
   isSubmit: false,
   onClick: undefined,

--- a/client/src/components/atoms/checkbox/CheckBox/CheckBox.tsx
+++ b/client/src/components/atoms/checkbox/CheckBox/CheckBox.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import myColor from '@theme/color';
 
 interface Props extends DescriptionProps, BoxProps {
   description: string;
@@ -25,7 +26,7 @@ const CheckBox = styled.div`
 
 const Mark = styled.svg`
   fill: none;
-  stroke: white;
+  stroke: ${myColor.primary.white};
   stroke-width: 3px;
 `;
 

--- a/client/src/components/atoms/div/ToggleButton/ToggleButton.tsx
+++ b/client/src/components/atoms/div/ToggleButton/ToggleButton.tsx
@@ -34,7 +34,7 @@ const ToggleButtonContainer = styled.div<sizeProps>`
 `;
 
 let leftColor = myColor.primary.accent;
-let rightColor = 'white';
+let rightColor = myColor.primary.white;
 
 const ToggleButton: React.FC<Props> = ({
   initRight,
@@ -46,11 +46,11 @@ const ToggleButton: React.FC<Props> = ({
 }: Props) => {
   const changeColor = (isLeft) => {
     if (isLeft === false) {
-      leftColor = 'white';
+      leftColor = myColor.primary.white;
       rightColor = myColor.primary.accent;
     } else {
       leftColor = myColor.primary.accent;
-      rightColor = 'white';
+      rightColor = myColor.primary.white;
     }
   };
 

--- a/client/src/components/atoms/graph/PieGraph/PieGraph.stories.tsx
+++ b/client/src/components/atoms/graph/PieGraph/PieGraph.stories.tsx
@@ -32,7 +32,7 @@ export const pieGraph = (): JSX.Element => {
     myColor.statistic.incomeThree,
     myColor.statistic.incomeFour,
   ];
-  return <PieGraph data={incomeData} colors={incomeColor} />;
+  return <PieGraph data={incomeData} colors={incomeColor} size={500} />;
 };
 
 pieGraph.story = {

--- a/client/src/components/atoms/graph/PieGraph/PieGraph.stories.tsx
+++ b/client/src/components/atoms/graph/PieGraph/PieGraph.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import myColor from '@theme/color';
+import PieGraph from './PieGraph';
+
+export default {
+  title: 'Atoms/graph/PieGraph',
+  component: PieGraph,
+};
+
+export const pieGraph = (): JSX.Element => {
+  const incomeData = [
+    {
+      name: '기타수입',
+      money: 8480,
+      percent: 45.4,
+    },
+    {
+      name: '용돈',
+      money: 5400,
+      percent: 28.9,
+    },
+    {
+      name: '사업수입',
+      money: 4804,
+      percent: 25.7,
+    },
+  ];
+
+  const incomeColor = [
+    myColor.statistic.incomeOne,
+    myColor.statistic.incomeTwo,
+    myColor.statistic.incomeThree,
+    myColor.statistic.incomeFour,
+  ];
+  return <PieGraph data={incomeData} colors={incomeColor} />;
+};
+
+pieGraph.story = {
+  name: 'PieGraph',
+};

--- a/client/src/components/atoms/graph/PieGraph/PieGraph.stories.tsx
+++ b/client/src/components/atoms/graph/PieGraph/PieGraph.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import myColor from '@theme/color';
+import { incomeColor } from '@theme/color';
 import PieGraph from './PieGraph';
 
 export default {
@@ -26,12 +26,6 @@ export const pieGraph = (): JSX.Element => {
     },
   ];
 
-  const incomeColor = [
-    myColor.statistic.incomeOne,
-    myColor.statistic.incomeTwo,
-    myColor.statistic.incomeThree,
-    myColor.statistic.incomeFour,
-  ];
   return <PieGraph data={incomeData} colors={incomeColor} size={500} />;
 };
 

--- a/client/src/components/atoms/graph/PieGraph/PieGraph.tsx
+++ b/client/src/components/atoms/graph/PieGraph/PieGraph.tsx
@@ -34,8 +34,8 @@ const SVG = styled.svg<SVGProps>`
   version: 1.1;
   baseProfile: full;
   width: ${(props) => props.size}px;
-  height: ${(props) => props.size}px;
-  viewBox: 0 0 ${(props) => props.size} ${(props) => props.size};
+  height: ${(props) => props.size + 100}px;
+  viewBox: 0 0 ${(props) => props.size} ${(props) => props.size + 100};
   xmlns: http://www.w3.org/2000/svg';
 `;
 
@@ -54,15 +54,15 @@ const Group = styled.g<GroupProps>`
 
 const Text = styled.text`
   display: none;
-  font-size: 16px;
+  font-size: 14px;
   text-anchor: middle;
 `;
 
 const PercentText = styled.text`
   display: none;
   stroke: ${myColor.primary.reject};
-  stroke-width: 4;
-  font-size: 36px;
+  stroke-width: 3;
+  font-size: 24px;
   text-anchor: middle;
 `;
 
@@ -148,10 +148,10 @@ const PieGraph: React.FC<Props> = ({ size, data, colors, fontColor, backgroundCo
           fill={color}
           d={toPieChartItemPath(chartSize, chartSize, radiusIn, radiusOut, start, end)}
         />
-        <Text x="50%" y="45%">
+        <Text x="50%" y="93%">
           {info}
         </Text>
-        <PercentText x="50%" y="55%">
+        <PercentText x="50%" y="47%">
           {Math.round(percent)} %
         </PercentText>
       </Group>

--- a/client/src/components/atoms/graph/PieGraph/PieGraph.tsx
+++ b/client/src/components/atoms/graph/PieGraph/PieGraph.tsx
@@ -1,17 +1,29 @@
 import React from 'react';
 import styled from 'styled-components';
+import myColor from '@theme/color';
+import getRandomKey from '@utils/random';
+import { numberToMoney } from '@utils/number';
 
-interface Props extends SVGProps {
+interface Props extends SVGProps, GroupProps, PathProps {
   data: any;
   colors: string[];
 }
 
 interface SVGProps {
-  size?: number;
+  size: number;
+}
+
+interface GroupProps {
+  fontColor?: string;
+}
+
+interface PathProps {
+  backgroundColor?: string;
 }
 
 const defaultProps = {
-  size: 500,
+  fontColor: myColor.primary.black,
+  backgroundColor: 'white',
 };
 
 const SVG = styled.svg<SVGProps>`
@@ -23,12 +35,50 @@ const SVG = styled.svg<SVGProps>`
   baseProfile: full;
   width: ${(props) => props.size}px;
   height: ${(props) => props.size}px;
+  viewBox: 0 0 ${(props) => props.size} ${(props) => props.size};
   xmlns: http://www.w3.org/2000/svg';
 `;
 
-const RowBarGraph: React.FC<Props> = ({ size, data, colors }: Props) => {
+const Group = styled.g<GroupProps>`
+  &:hover,
+  &:active {
+    text {
+      display: block;
+    }
+  }
+
+  text {
+    fill: ${(props) => props.fontColor};
+  }
+`;
+
+const Text = styled.text`
+  display: none;
+  font-size: 16px;
+  text-anchor: middle;
+`;
+
+const PercentText = styled.text`
+  display: none;
+  stroke: ${myColor.primary.reject};
+  stroke-width: 4;
+  font-size: 36px;
+  text-anchor: middle;
+`;
+
+const Path = styled.path<PathProps>`
+  stroke: ${(props) => props.color};
+  &:hover,
+  &:active {
+    position: relative;
+    stroke: ${(props) => props.backgroundColor};
+    stroke-width: 20;
+  }
+`;
+
+const PieGraph: React.FC<Props> = ({ size, data, colors, fontColor, backgroundColor }: Props) => {
   const toXY = (cX: number, cY: number, r: number, degrees: number) => {
-    const rad = (degrees * Math.PI) / 180.0;
+    const rad = ((degrees - 90) * Math.PI) / 180.0;
     return {
       x: cX + r * Math.cos(rad),
       y: cY + r * Math.sin(rad),
@@ -79,14 +129,32 @@ const RowBarGraph: React.FC<Props> = ({ size, data, colors }: Props) => {
     return d;
   };
 
-  const pieComponent = (key: string, color: string, start: number, end: number) => {
+  const pieComponent = (
+    info: string,
+    color: string,
+    start: number,
+    end: number,
+    percent: number,
+  ) => {
     const chartSize = Math.round(size / 2);
+    const radiusIn = Math.round(size / 5);
+    const radiusOut = Math.round(size / 2.2);
     return (
-      <path
-        key={key}
-        fill={color}
-        d={toPieChartItemPath(chartSize, chartSize, 100, 240, start, end)}
-      />
+      <Group fontColor={fontColor} key={getRandomKey()}>
+        <Path
+          backgroundColor={backgroundColor}
+          color={color}
+          key={getRandomKey()}
+          fill={color}
+          d={toPieChartItemPath(chartSize, chartSize, radiusIn, radiusOut, start, end)}
+        />
+        <Text x="50%" y="45%">
+          {info}
+        </Text>
+        <PercentText x="50%" y="55%">
+          {Math.round(percent)} %
+        </PercentText>
+      </Group>
     );
   };
 
@@ -94,8 +162,10 @@ const RowBarGraph: React.FC<Props> = ({ size, data, colors }: Props) => {
     const pieComponents: any[] = [];
     let radiusSum = 0;
     data.forEach((element, index) => {
-      const radius = element.percent * 3.6;
-      const component = pieComponent(element.name, colors[index], radiusSum, radiusSum + radius);
+      const { name, money, percent } = element;
+      const radius = percent * 3.6;
+      const info = `${name} : ${numberToMoney(money)} 원`;
+      const component = pieComponent(info, colors[index], radiusSum, radiusSum + radius, percent);
       pieComponents.push(component);
       radiusSum += radius;
     });
@@ -109,6 +179,6 @@ const RowBarGraph: React.FC<Props> = ({ size, data, colors }: Props) => {
   );
 };
 
-RowBarGraph.defaultProps = defaultProps;
+PieGraph.defaultProps = defaultProps;
 
-export default RowBarGraph;
+export default PieGraph;

--- a/client/src/components/atoms/graph/PieGraph/PieGraph.tsx
+++ b/client/src/components/atoms/graph/PieGraph/PieGraph.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface Props extends SVGProps {
+  data: any;
+  colors: string[];
+}
+
+interface SVGProps {
+  size?: number;
+}
+
+const defaultProps = {
+  size: 500,
+};
+
+const SVG = styled.svg<SVGProps>`
+  display: block;
+  margin: 0px;
+  padding: 0px;
+  border: 0px;
+  version: 1.1;
+  baseProfile: full;
+  width: ${(props) => props.size}px;
+  height: ${(props) => props.size}px;
+  xmlns: http://www.w3.org/2000/svg';
+`;
+
+const RowBarGraph: React.FC<Props> = ({ size, data, colors }: Props) => {
+  const toXY = (cX: number, cY: number, r: number, degrees: number) => {
+    const rad = (degrees * Math.PI) / 180.0;
+    return {
+      x: cX + r * Math.cos(rad),
+      y: cY + r * Math.sin(rad),
+    };
+  };
+
+  const toPieChartItemPath = (
+    x: number,
+    y: number,
+    radiusIn: number,
+    radiusOut: number,
+    startAngle: number,
+    endAngle: number,
+  ) => {
+    const startIn = toXY(x, y, radiusIn, endAngle);
+    const endIn = toXY(x, y, radiusIn, startAngle);
+    const startOut = toXY(x, y, radiusOut, endAngle);
+    const endOut = toXY(x, y, radiusOut, startAngle);
+    const arcSweep = endAngle - startAngle <= 180 ? '0' : '1';
+    const d = [
+      'M',
+      startIn.x,
+      startIn.y,
+      'L',
+      startOut.x,
+      startOut.y,
+      'A',
+      radiusOut,
+      radiusOut,
+      0,
+      arcSweep,
+      0,
+      endOut.x,
+      endOut.y,
+      'L',
+      endIn.x,
+      endIn.y,
+      'A',
+      radiusIn,
+      radiusIn,
+      0,
+      arcSweep,
+      1,
+      startIn.x,
+      startIn.y,
+      'z',
+    ].join(' ');
+    return d;
+  };
+
+  const pieComponent = (key: string, color: string, start: number, end: number) => {
+    const chartSize = Math.round(size / 2);
+    return (
+      <path
+        key={key}
+        fill={color}
+        d={toPieChartItemPath(chartSize, chartSize, 100, 240, start, end)}
+      />
+    );
+  };
+
+  const drawPieChart = () => {
+    const pieComponents: any[] = [];
+    let radiusSum = 0;
+    data.forEach((element, index) => {
+      const radius = element.percent * 3.6;
+      const component = pieComponent(element.name, colors[index], radiusSum, radiusSum + radius);
+      pieComponents.push(component);
+      radiusSum += radius;
+    });
+
+    return pieComponents;
+  };
+  return (
+    <>
+      <SVG size={size}>{drawPieChart()}</SVG>
+    </>
+  );
+};
+
+RowBarGraph.defaultProps = defaultProps;
+
+export default RowBarGraph;

--- a/client/src/components/atoms/graph/PieGraph/PieGraph.tsx
+++ b/client/src/components/atoms/graph/PieGraph/PieGraph.tsx
@@ -23,7 +23,7 @@ interface PathProps {
 
 const defaultProps = {
   fontColor: myColor.primary.black,
-  backgroundColor: 'white',
+  backgroundColor: myColor.primary.white,
 };
 
 const SVG = styled.svg<SVGProps>`

--- a/client/src/components/atoms/graph/PieGraph/index.ts
+++ b/client/src/components/atoms/graph/PieGraph/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PieGraph';

--- a/client/src/components/molecules/ChangeAccountbookColorCard/ChangeAccountbookColorCard.tsx
+++ b/client/src/components/molecules/ChangeAccountbookColorCard/ChangeAccountbookColorCard.tsx
@@ -21,7 +21,7 @@ interface squircleCardProps {
 const squircleCardArgs: squircleCardProps = {
   width: '100%',
   height: '10rem',
-  backgroundColor: 'white',
+  backgroundColor: myColor.primary.white,
   flexFlow: 'column',
 };
 

--- a/client/src/components/molecules/InviteAccountbookCard/InviteAccountbookCard.tsx
+++ b/client/src/components/molecules/InviteAccountbookCard/InviteAccountbookCard.tsx
@@ -21,7 +21,7 @@ interface squircleCardProps {
 const squircleCardArgs: squircleCardProps = {
   width: '100%',
   height: '10rem',
-  backgroundColor: 'white',
+  backgroundColor: myColor.primary.white,
   flexFlow: 'column',
 };
 

--- a/client/src/components/molecules/Modal/Modal.tsx
+++ b/client/src/components/molecules/Modal/Modal.tsx
@@ -49,7 +49,7 @@ const Modal = styled.div<modalProps>`
   max-width: 800px;
   width: ${(props) => props.width};
   height: ${(props) => props.height};
-  background-color: white;
+  background-color: ${myColor.primary.white};
   box-shadow: 8px 8px 8px -4px #7b7b7b;
   border: 0;
   border-radius: 8px;

--- a/client/src/components/molecules/StickWithText/StickWithText.tsx
+++ b/client/src/components/molecules/StickWithText/StickWithText.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 const StickWithText = styled.div`
   display: flex;
-  color: white;
+  color: ${myColor.primary.white};
   align-items: center;
   justify-content: space-around;
   font-size: 0.8rem;

--- a/client/src/components/organisms/FiveWeekStatistics/FiveWeekStatistics.tsx
+++ b/client/src/components/organisms/FiveWeekStatistics/FiveWeekStatistics.tsx
@@ -32,7 +32,7 @@ const Container = styled.div`
 
 const TitleBox = styled.div`
   display: flex;
-  color: white;
+  color: ${myColor.primary.white};
   align-items: center;
   justify-content: space-around;
   font-size: 0.8rem;
@@ -45,7 +45,7 @@ const TitleBox = styled.div`
 
 const TotalBox = styled.div`
   display: flex;
-  color: white;
+  color: ${myColor.primary.white};
   align-items: center;
   justify-content: space-around;
   font-size: 0.8rem;
@@ -59,7 +59,7 @@ const TotalBox = styled.div`
 const WeekBox = styled.div`
   display: flex;
   justify-content: center;
-  color: white;
+  color: ${myColor.primary.white};
   align-items: center;
   font-size: 0.1rem;
   width: 100%;

--- a/client/src/components/organisms/FourMonthStatistics/FourMonthStatistics.tsx
+++ b/client/src/components/organisms/FourMonthStatistics/FourMonthStatistics.tsx
@@ -28,7 +28,7 @@ const Container = styled.div`
 
 const InfoBox = styled.div`
   display: flex;
-  color: white;
+  color: ${myColor.primary.white};
   align-items: center;
   justify-content: space-around;
   font-size: 0.5rem;
@@ -41,7 +41,7 @@ const InfoBox = styled.div`
 const ConvexMonthBtn = styled.div`
   width: 20%;
   height: 60%;
-  color: white;
+  color: ${myColor.primary.white};
   border-radius: 10px;
   background: #2f2e2d;
   box-shadow: 5px 5px 10px #171616, -5px -5px 10px #474644;
@@ -55,7 +55,7 @@ const ConvexMonthBtn = styled.div`
 const PressedMonthBtn = styled.div`
   width: 20%;
   height: 60%;
-  color: white;
+  color: ${myColor.primary.white};
   border-radius: 10px;
   background: #2f2e2d;
   box-shadow: inset 5px 5px 8px #131212, inset -5px -5px 8px #4b4a48;

--- a/client/src/components/organisms/PieChart/PieChart.stories.tsx
+++ b/client/src/components/organisms/PieChart/PieChart.stories.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PieChart from './PieChart';
+
+export default {
+  title: 'Organisms/PieChart',
+  component: PieChart,
+};
+
+export const pieChart = (): JSX.Element => {
+  const isIncome = true;
+  const data = {
+    income: [
+      {
+        name: '기타수입',
+        money: 8480,
+        percent: 45.4,
+      },
+      {
+        name: '용돈',
+        money: 5400,
+        percent: 28.9,
+      },
+      {
+        name: '사업수입',
+        money: 4804,
+        percent: 25.7,
+      },
+    ],
+    expenditure: [
+      {
+        name: '식비',
+        money: 95190,
+        percent: 100,
+      },
+    ],
+  };
+  return <PieChart data={data} isIncome={isIncome} />;
+};
+
+pieChart.story = {
+  name: 'PieChart',
+};

--- a/client/src/components/organisms/PieChart/PieChart.tsx
+++ b/client/src/components/organisms/PieChart/PieChart.tsx
@@ -9,8 +9,8 @@ interface Props {
 }
 
 const Container = styled.div`
-  width: 550px;
-  height: 550px;
+  width: 90%;
+  height: 20rem;
   padding: 1rem;
   box-sizing: border-box;
   border-radius: 15px;
@@ -20,7 +20,7 @@ const Container = styled.div`
   margin-bottom: 1rem;
   display: flex;
   flex-flow: column;
-  justify-content: space-between;
+  align-items: center;
 `;
 
 const pieChart: React.FC<Props> = ({ data, isIncome }: Props) => {
@@ -28,7 +28,7 @@ const pieChart: React.FC<Props> = ({ data, isIncome }: Props) => {
     <PieGraph
       data={chartData}
       colors={color}
-      size={500}
+      size={250}
       backgroundColor={myColor.primary.black}
       fontColor="white"
     />

--- a/client/src/components/organisms/PieChart/PieChart.tsx
+++ b/client/src/components/organisms/PieChart/PieChart.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import styled from 'styled-components';
+import PieGraph from '@atoms/graph/PieGraph';
+import myColor from '@theme/color';
+
+interface Props {
+  data: any;
+  isIncome: boolean;
+}
+
+const Container = styled.div`
+  width: 550px;
+  height: 550px;
+  padding: 1rem;
+  box-sizing: border-box;
+  border-radius: 15px;
+  background-color: ${myColor.primary.black};
+  box-shadow: 0px 7px 15px 2px ${myColor.primary.gray};
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  display: flex;
+  flex-flow: column;
+  justify-content: space-between;
+`;
+
+const pieChart: React.FC<Props> = ({ data, isIncome }: Props) => {
+  const incomeColor = [
+    myColor.statistic.incomeOne,
+    myColor.statistic.incomeTwo,
+    myColor.statistic.incomeThree,
+    myColor.statistic.incomeFour,
+  ];
+  const expenditureColor = [
+    myColor.statistic.expenditureOne,
+    myColor.statistic.expenditureTwo,
+    myColor.statistic.expenditureThree,
+    myColor.statistic.expenditureFour,
+  ];
+
+  const incomePieChart = () => <PieGraph data={data.income} colors={incomeColor} size={500} />;
+  const expenditurePieChart = () => (
+    <PieGraph data={data.expenditure} colors={expenditureColor} size={500} />
+  );
+
+  return <Container>{isIncome ? incomePieChart() : expenditurePieChart()}</Container>;
+};
+
+export default pieChart;

--- a/client/src/components/organisms/PieChart/PieChart.tsx
+++ b/client/src/components/organisms/PieChart/PieChart.tsx
@@ -37,12 +37,23 @@ const pieChart: React.FC<Props> = ({ data, isIncome }: Props) => {
     myColor.statistic.expenditureFour,
   ];
 
-  const incomePieChart = () => <PieGraph data={data.income} colors={incomeColor} size={500} />;
-  const expenditurePieChart = () => (
-    <PieGraph data={data.expenditure} colors={expenditureColor} size={500} />
+  const drawChart = (chartData: any, color: string[]) => (
+    <PieGraph
+      data={chartData}
+      colors={color}
+      size={500}
+      backgroundColor={myColor.primary.black}
+      fontColor="white"
+    />
   );
 
-  return <Container>{isIncome ? incomePieChart() : expenditurePieChart()}</Container>;
+  return (
+    <Container>
+      {isIncome
+        ? drawChart(data.income, incomeColor)
+        : drawChart(data.expenditure, expenditureColor)}
+    </Container>
+  );
 };
 
 export default pieChart;

--- a/client/src/components/organisms/PieChart/PieChart.tsx
+++ b/client/src/components/organisms/PieChart/PieChart.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import PieGraph from '@atoms/graph/PieGraph';
-import myColor from '@theme/color';
+import myColor, { incomeColor, expenditureColor } from '@theme/color';
 
 interface Props {
   data: any;
@@ -24,19 +24,6 @@ const Container = styled.div`
 `;
 
 const pieChart: React.FC<Props> = ({ data, isIncome }: Props) => {
-  const incomeColor = [
-    myColor.statistic.incomeOne,
-    myColor.statistic.incomeTwo,
-    myColor.statistic.incomeThree,
-    myColor.statistic.incomeFour,
-  ];
-  const expenditureColor = [
-    myColor.statistic.expenditureOne,
-    myColor.statistic.expenditureTwo,
-    myColor.statistic.expenditureThree,
-    myColor.statistic.expenditureFour,
-  ];
-
   const drawChart = (chartData: any, color: string[]) => (
     <PieGraph
       data={chartData}

--- a/client/src/components/organisms/PieChart/index.ts
+++ b/client/src/components/organisms/PieChart/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PieChart';

--- a/client/src/components/organisms/StickChart/StickChart.tsx
+++ b/client/src/components/organisms/StickChart/StickChart.tsx
@@ -39,7 +39,7 @@ const stickChart: React.FC<Props> = ({ data, isIncome }: Props) => {
       const money = Number(ele.money);
       const percent = Number(ele.percent);
       const inColor: any = incomeColor[index];
-      const outColor = 'white';
+      const outColor = myColor.primary.white;
       const height = '40px';
       const width = '85%';
       return (
@@ -62,7 +62,7 @@ const stickChart: React.FC<Props> = ({ data, isIncome }: Props) => {
       const money = Number(ele.money);
       const percent = Number(ele.percent);
       const inColor: any = expenditureColor[index];
-      const outColor = 'white';
+      const outColor = myColor.primary.white;
       const height = '40px';
       const width = '85%';
       return (

--- a/client/src/components/organisms/StickChart/StickChart.tsx
+++ b/client/src/components/organisms/StickChart/StickChart.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
+import myColor, { incomeColor, expenditureColor } from '@theme/color';
 import StickWithText from '@molecules/StickWithText';
-import myColor from '@theme/color';
 import getRandomKey from '@utils/random';
 
 interface Props {
@@ -25,18 +25,6 @@ const StickChart = styled.div`
 `;
 
 const stickChart: React.FC<Props> = ({ data, isIncome }: Props) => {
-  const incomeColor = [
-    myColor.statistic.incomeOne,
-    myColor.statistic.incomeTwo,
-    myColor.statistic.incomeThree,
-    myColor.statistic.incomeFour,
-  ];
-  const expenditureColor = [
-    myColor.statistic.expenditureOne,
-    myColor.statistic.expenditureTwo,
-    myColor.statistic.expenditureThree,
-    myColor.statistic.expenditureFour,
-  ];
   let maxFourIncome = [];
   let maxFourExpenditure = [];
   if (data.income) {

--- a/client/src/theme/color.ts
+++ b/client/src/theme/color.ts
@@ -43,16 +43,24 @@ const myColor: Colors = {
     border: '#dadada',
     main: '#efefef',
   },
-  statistic: {
-    expenditureOne: '#324F7E',
-    expenditureTwo: '#5A75A1',
-    expenditureThree: '#859BBF',
-    expenditureFour: '#A7BBDB',
-    incomeOne: '#D4D424',
-    incomeTwo: '#E2E24E',
-    incomeThree: '#EFEF8C',
-    incomeFour: '#F7F788',
-  },
 };
+
+export const incomeColor = ['#FFD969', '#FFD03D', '#CCA531', '#80671F', '#665B37'];
+
+export const expenditureColor = [
+  '#2E2F78',
+  '#4648B8',
+  '#5457DE',
+  '#5F61F8',
+  '#4A74E0',
+  '#53AFFC',
+  '#40C7E6',
+  '#47DFEF',
+  '#91E9F2',
+  '#BBF2F4',
+  '#97A6A8',
+  '#656F70',
+  '#454C4D',
+];
 
 export default myColor;

--- a/client/src/views/StatisticsPage.tsx
+++ b/client/src/views/StatisticsPage.tsx
@@ -35,7 +35,7 @@ const StatisticsPage: React.FC = () => {
   const dateData = `${year}-${month}`;
 
   const [isIncome, setIsIncome] = useState(false);
-  const [isExpenditure, setIsExpenditure] = useState(false);
+  const [, setIsExpenditure] = useState(false);
   const [fourMonthData, setFourMonthData] = useState([]);
   const [fiveWeekData, setFiveWeekData] = useState([]);
   const [categoryData, setCategoryData] = useState(initCategory);
@@ -71,13 +71,6 @@ const StatisticsPage: React.FC = () => {
         break;
     }
   };
-
-  useEffect(() => {
-    console.log(isIncome);
-    console.log(isExpenditure);
-    console.log(accountbookType);
-    console.log(accountbookId);
-  }, [dateData]);
 
   useEffect(() => {
     initFourMonthData();

--- a/client/src/views/StatisticsPage.tsx
+++ b/client/src/views/StatisticsPage.tsx
@@ -5,6 +5,7 @@ import ColumFlexContainer from '@atoms/div/ColumnFlexContainer';
 import FourMonthStatistics from '@organisms/FourMonthStatistics';
 import FiveWeekStatistics from '@organisms/FiveWeekStatistics';
 import StickStatistics from '@organisms/StickChart';
+import PieStatistics from '@organisms/PieChart';
 import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
 import { getAxiosData } from '@utils/axios';
@@ -21,6 +22,11 @@ const Container = styled.div`
   border-radius: 5px;
 `;
 
+const initCategory = {
+  income: [],
+  expenditure: [],
+};
+
 const StatisticsPage: React.FC = () => {
   const year = useSelector((state: RootState) => state.date.year);
   const month = useSelector((state: RootState) => state.date.month);
@@ -32,7 +38,7 @@ const StatisticsPage: React.FC = () => {
   const [isExpenditure, setIsExpenditure] = useState(false);
   const [fourMonthData, setFourMonthData] = useState([]);
   const [fiveWeekData, setFiveWeekData] = useState([]);
-  const [stickData, setStickData] = useState({});
+  const [categoryData, setCategoryData] = useState(initCategory);
 
   const initFourMonthData = async () => {
     const master =
@@ -55,11 +61,11 @@ const StatisticsPage: React.FC = () => {
     switch (accountbookType) {
       case 'PRIVATE':
         result = await getAxiosData(API.GET_PRIVATE_STATISTIC_CATEGORY(year, month));
-        setStickData(result.data);
+        setCategoryData(result.data);
         break;
       case 'SOCIAL':
         result = await getAxiosData(API.GET_SOCIAL_STATISTIC_CATEGORY(accountbookId, year, month));
-        setStickData(result.data);
+        setCategoryData(result.data);
         break;
       default:
         break;
@@ -91,7 +97,8 @@ const StatisticsPage: React.FC = () => {
         rightCallback={setIsExpenditure}
       />
       <ColumFlexContainer width="100%" alignItems="center">
-        <StickStatistics data={stickData} isIncome={isIncome} />
+        <PieStatistics data={categoryData} isIncome={isIncome} />
+        <StickStatistics data={categoryData} isIncome={isIncome} />
         <FiveWeekStatistics data={fiveWeekData} isIncome={isIncome} />
         <FourMonthStatistics data={fourMonthData} />
       </ColumFlexContainer>


### PR DESCRIPTION
### 📕 Issue Number

Close #97 
<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- pieGraph molecules 개발
- pieChart organisms 개발
- 통계에서 사용하는 income, expenditure color 분리
    - `utils/color`에 배열로 따로 분리해주었습니다.
- 통계 페이지에 파이 차트를 적용하였습니다.
![React-App-Chrome-2020-12-15-02-44-30](https://user-images.githubusercontent.com/50297117/102116408-44722780-3e80-11eb-8cb0-170946a15866.gif)

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 추후 시간이 남는다면 애니메이션을 추가해도 좋을 것 같습니다.
- 모바일버전의 디자인만 고려하였습니다.
- 초기 svg 의 틀을 잡는 것은 [링크](http://www.gisdeveloper.co.kr/?p=4705&unapproved=30494&moderation-hash=2dd8a7ec9ffc9f43e8261c36f23beced#comment-30494)를 참고하여 진행하였습니다.
<br/><br/>