### PR TITLE
BE-feat-테스트 계정 토큰생성용 API 구현

### DIFF
--- a/server/.env.sample
+++ b/server/.env.sample
@@ -22,3 +22,5 @@ JWT_EXPIRE = [JWT 기간설정]
 DEFAULT_IMG = [DEFAULT_IMG]
 # 인증 실패
 LOGIN_URL = [인증실패 리다이렉트 URL]
+# testAccount
+TEST_ACCOUNT = [테스트 계정 list JSON]

--- a/server/src/interface/user.ts
+++ b/server/src/interface/user.ts
@@ -5,7 +5,7 @@ interface OauthOption {
 }
 
 interface OauthUserData {
-  name: string;
+  name?: string;
   id: string;
   oAuthOrigin?: string;
   uid?: string;

--- a/server/src/oauth/controller.ts
+++ b/server/src/oauth/controller.ts
@@ -1,8 +1,8 @@
 import 'dotenv/config';
 import * as Service from './service';
-import { InsertUser } from '../interface/user';
+import { InsertUser, OauthUserData } from '../interface/user';
 
-const oauth = async (ctx: any) => {
+export const oauth = async (ctx: any) => {
   const { code, site, state } = ctx.request.body;
 
   let client_id: string = '';
@@ -79,4 +79,14 @@ const oauth = async (ctx: any) => {
   ctx.body = jwtToken;
 };
 
-export { oauth };
+export const testAccount = async (ctx: any) => {
+  const { id } = ctx.params;
+  const testAcount: any = JSON.parse(process.env.TEST_ACCOUNT as string);
+  const data: OauthUserData = {
+    id: testAcount.list[id - 1].id,
+    uid: testAcount.list[id - 1].uid,
+  };
+
+  const jwtToken = Service.createJWTtoken(data, 'github');
+  ctx.body = jwtToken;
+};

--- a/server/src/oauth/router.ts
+++ b/server/src/oauth/router.ts
@@ -6,4 +6,6 @@ const router = new Router();
 
 router.post('/login', Controller.oauth);
 
+router.get('/login/test/:id', Controller.testAccount);
+
 export default router;


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- .env에 TEST_ACCOUNT 항목을 추가해야 합니다 (카톡 내용 참조)
- URL : [GET] :3000/login/test/:id
- id의 범위는 1~4까지
- 팀원 4명의 GitHub 계정을 각각 Mapping 하였습니다

- 예시
```JSON
# request GET http://127.0.0.1:3000/login/test/1

# response body
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDYwOTkxMTUsIm9BdXRoT3JpZ2luIjoiZ2
l0aHViIiwidWlkIjoxNiwiaWF0IjoxNjA4MDE3MDY4LCJleHAiOjE2MDgxMDM0Njh9.8tmWbD
oz9mOrCl28mhhu08ZkLIocTWaGGNejG2vNBL0
```
<br/>

### 📘 작업 유형

- 신규 기능 추가
<br/>