### PR TITLE
FE-feat 초대 모달 UI & 상태 구현 완료

### DIFF
--- a/client/src/components/atoms/button/NavButton/NavButton.tsx
+++ b/client/src/components/atoms/button/NavButton/NavButton.tsx
@@ -10,6 +10,7 @@ interface Props extends backgroundColorProps {
   iconColor?: string;
   width?: string;
   height?: string;
+  onClick?: () => void;
 }
 
 interface backgroundColorProps {
@@ -23,6 +24,7 @@ const defaultProps = {
   iconColor: 'none',
   width: '2rem',
   height: '2rem',
+  onClick: undefined,
 };
 
 const Button = styled.button<backgroundColorProps>`
@@ -39,6 +41,7 @@ const NavButton: React.FC<Props> = ({
   moveUrl,
   width,
   height,
+  onClick,
 }: Props) => {
   const selectIcon = (icon: string) => {
     switch (icon) {
@@ -52,7 +55,7 @@ const NavButton: React.FC<Props> = ({
   };
 
   return (
-    <Button width={width} height={height} backgroundColor={backgroundColor}>
+    <Button onClick={onClick} width={width} height={height} backgroundColor={backgroundColor}>
       <Link to={moveUrl}>{selectIcon(name)}</Link>
     </Button>
   );

--- a/client/src/components/molecules/UserInviteCard/UserInviteCard.stories.tsx
+++ b/client/src/components/molecules/UserInviteCard/UserInviteCard.stories.tsx
@@ -3,7 +3,8 @@ import UserInviteCard from './UserInviteCard';
 
 interface Props {
   link: string;
-  id: number;
+  userId: number;
+  stateId: number;
   bookId: number;
   name: string;
   callback: (boolean) => void;
@@ -18,7 +19,8 @@ export default {
 
 export const userInviteCard = ({
   link,
-  id,
+  stateId,
+  userId,
   bookId,
   name,
   callback,
@@ -28,7 +30,8 @@ export const userInviteCard = ({
   return (
     <UserInviteCard
       link={link}
-      id={id}
+      stateId={stateId}
+      userId={userId}
       bookId={bookId}
       name={name}
       callback={callback}

--- a/client/src/components/molecules/UserInviteCard/UserInviteCard.stories.tsx
+++ b/client/src/components/molecules/UserInviteCard/UserInviteCard.stories.tsx
@@ -7,7 +7,6 @@ interface Props {
   stateId: number;
   bookId: number;
   name: string;
-  callback: (boolean) => void;
   backgroundColor: string;
   buttonName: string;
 }
@@ -23,7 +22,6 @@ export const userInviteCard = ({
   userId,
   bookId,
   name,
-  callback,
   backgroundColor,
   buttonName,
 }: Props): JSX.Element => {
@@ -34,7 +32,6 @@ export const userInviteCard = ({
       userId={userId}
       bookId={bookId}
       name={name}
-      callback={callback}
       backgroundColor={backgroundColor}
       buttonName={buttonName}
     />

--- a/client/src/components/molecules/UserInviteCard/UserInviteCard.stories.tsx
+++ b/client/src/components/molecules/UserInviteCard/UserInviteCard.stories.tsx
@@ -7,6 +7,7 @@ interface Props {
   stateId: number;
   bookId: number;
   name: string;
+  callback: any;
   backgroundColor: string;
   buttonName: string;
 }
@@ -22,6 +23,7 @@ export const userInviteCard = ({
   userId,
   bookId,
   name,
+  callback,
   backgroundColor,
   buttonName,
 }: Props): JSX.Element => {
@@ -31,6 +33,7 @@ export const userInviteCard = ({
       stateId={stateId}
       userId={userId}
       bookId={bookId}
+      callback={callback}
       name={name}
       backgroundColor={backgroundColor}
       buttonName={buttonName}

--- a/client/src/components/molecules/UserInviteCard/UserInviteCard.tsx
+++ b/client/src/components/molecules/UserInviteCard/UserInviteCard.tsx
@@ -12,6 +12,7 @@ interface Props {
   userId: number;
   bookId: number;
   name: string;
+  callback: any;
   backgroundColor: string;
   buttonName: string;
 }
@@ -22,6 +23,7 @@ const userInviteCard: React.FC<Props> = ({
   userId,
   bookId,
   name,
+  callback,
   backgroundColor,
   buttonName,
 }: Props) => {
@@ -35,6 +37,7 @@ const userInviteCard: React.FC<Props> = ({
       };
       await postAxios(API.POST_SOCIAL_INVITATION, data);
     }
+    callback();
   };
 
   return (

--- a/client/src/components/molecules/UserInviteCard/UserInviteCard.tsx
+++ b/client/src/components/molecules/UserInviteCard/UserInviteCard.tsx
@@ -4,7 +4,7 @@ import Name from '@atoms/p/CenterNormalText/CenterNormalText';
 import RoundShortButton from '@atoms/button/RoundShortButton';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import * as API from '@utils/api';
-import { postAxios } from '@utils/axios';
+import { postAxios, deleteAxios } from '@utils/axios';
 
 interface Props {
   link: string;
@@ -25,16 +25,16 @@ const userInviteCard: React.FC<Props> = ({
   backgroundColor,
   buttonName,
 }: Props) => {
-  console.log(stateId, userId, bookId);
-
-  // TODO onclick 에 id, bookid, 취소인지 초대하기인지 넘겨주기 ? Axios 로 데이터 보내기
   const setInvite = async () => {
-    const data = {
-      userId,
-      accountbookId: bookId,
-    };
-    const result = await postAxios(API.POST_SOCIAL_INVITATION, data);
-    console.log(data, result);
+    if (stateId) {
+      await deleteAxios(API.DELETE_SOCIAL_INVITATION(stateId));
+    } else {
+      const data = {
+        userId,
+        accountbookId: bookId,
+      };
+      await postAxios(API.POST_SOCIAL_INVITATION, data);
+    }
   };
 
   return (

--- a/client/src/components/molecules/UserInviteCard/UserInviteCard.tsx
+++ b/client/src/components/molecules/UserInviteCard/UserInviteCard.tsx
@@ -3,14 +3,15 @@ import UserImage from '@atoms/img/UserImage/UserImage';
 import Name from '@atoms/p/CenterNormalText/CenterNormalText';
 import RoundShortButton from '@atoms/button/RoundShortButton';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
+import * as API from '@utils/api';
+import { postAxios } from '@utils/axios';
 
 interface Props {
   link: string;
-  stateId: number;
+  stateId?: number;
   userId: number;
   bookId: number;
   name: string;
-  callback: (boolean) => void;
   backgroundColor: string;
   buttonName: string;
 }
@@ -21,13 +22,20 @@ const userInviteCard: React.FC<Props> = ({
   userId,
   bookId,
   name,
-  callback,
   backgroundColor,
   buttonName,
 }: Props) => {
   console.log(stateId, userId, bookId);
 
   // TODO onclick 에 id, bookid, 취소인지 초대하기인지 넘겨주기 ? Axios 로 데이터 보내기
+  const setInvite = async () => {
+    const data = {
+      userId,
+      accountbookId: bookId,
+    };
+    const result = await postAxios(API.POST_SOCIAL_INVITATION, data);
+    console.log(data, result);
+  };
 
   return (
     <RowFlexContainer
@@ -40,7 +48,7 @@ const userInviteCard: React.FC<Props> = ({
     >
       <UserImage link={link} />
       <Name fontSize="10px">{name}</Name>
-      <RoundShortButton onClick={() => callback(true)}>{buttonName}</RoundShortButton>
+      <RoundShortButton onClick={() => setInvite()}>{buttonName}</RoundShortButton>
     </RowFlexContainer>
   );
 };

--- a/client/src/components/molecules/UserInviteCard/UserInviteCard.tsx
+++ b/client/src/components/molecules/UserInviteCard/UserInviteCard.tsx
@@ -6,7 +6,8 @@ import RowFlexContainer from '@atoms/div/RowFlexContainer';
 
 interface Props {
   link: string;
-  id: number;
+  stateId: number;
+  userId: number;
   bookId: number;
   name: string;
   callback: (boolean) => void;
@@ -16,14 +17,15 @@ interface Props {
 
 const userInviteCard: React.FC<Props> = ({
   link,
-  id,
+  stateId,
+  userId,
   bookId,
   name,
   callback,
   backgroundColor,
   buttonName,
 }: Props) => {
-  console.log(id, bookId);
+  console.log(stateId, userId, bookId);
 
   // TODO onclick 에 id, bookid, 취소인지 초대하기인지 넘겨주기 ? Axios 로 데이터 보내기
 

--- a/client/src/components/organisms/InvitationModal/InvitationModal.tsx
+++ b/client/src/components/organisms/InvitationModal/InvitationModal.tsx
@@ -56,6 +56,7 @@ const invitationModal: React.FC<Props> = ({ socialId }: Props) => {
     <RowFlexContainer>
       <UserInviteCard
         key={getRandomKey()}
+        callback={getWaitedUserList}
         userId={user.id}
         bookId={socialId}
         name={user.name}
@@ -70,6 +71,7 @@ const invitationModal: React.FC<Props> = ({ socialId }: Props) => {
     <RowFlexContainer>
       <UserInviteCard
         key={getRandomKey()}
+        callback={getWaitedUserList}
         stateId={user.id}
         userId={user.userId}
         bookId={socialId}
@@ -87,6 +89,7 @@ const invitationModal: React.FC<Props> = ({ socialId }: Props) => {
       <RowFlexContainer>
         <UserInviteCard
           key={getRandomKey()}
+          callback={getWaitedUserList}
           userId={user.id}
           bookId={socialId}
           name={user.name}
@@ -100,6 +103,7 @@ const invitationModal: React.FC<Props> = ({ socialId }: Props) => {
       <RowFlexContainer>
         <UserInviteCard
           key={getRandomKey()}
+          callback={getWaitedUserList}
           stateId={user.id}
           userId={user.userId}
           bookId={socialId}

--- a/client/src/components/organisms/InvitationModal/InvitationModal.tsx
+++ b/client/src/components/organisms/InvitationModal/InvitationModal.tsx
@@ -35,30 +35,20 @@ const invitationModal: React.FC<Props> = ({ socialId }: Props) => {
     setUserList(result.data);
   };
 
-  const getWaitedUserList = (socialAccountBookId) => {
-    // TODO AXIOS 로 social ID 를 통해 대기중인 유저 LIST 가져오기
-    console.log(socialAccountBookId);
-    const result = [
-      {
-        id: 23,
-        email: 'vnslt0152@gmail.com',
-        name: 'JunYoung Jang',
-        picture: 'https://avatars0.githubusercontent.com/u/61405355?v=4',
-      },
-      {
-        id: 24,
-        email: 'kjha2142@gmail.com',
-        name: 'Jaehee Kim',
-        picture: 'https://avatars2.githubusercontent.com/u/40454769?v=4',
-      },
-      {
-        id: 25,
-        email: 'maong0927@gmail.com',
-        name: 'Hera',
-        picture: 'https://avatars3.githubusercontent.com/u/20068470?v=4',
-      },
-    ];
-    setWaitedList(result);
+  const getWaitedUserList = async () => {
+    const { data } = await getAxiosData(API.GET_SOCIAL_WAITING_USER_LIST(socialId));
+    const newArgs: any = [];
+    // eslint-disable-next-line array-callback-return
+    data.map((ele) => {
+      newArgs.push({
+        id: ele.id,
+        userId: ele.user_id,
+        email: ele.email,
+        name: ele.name,
+        picture: ele.picture,
+      });
+    });
+    setWaitedList(newArgs);
   };
 
   const callback = () => {
@@ -69,7 +59,8 @@ const invitationModal: React.FC<Props> = ({ socialId }: Props) => {
     <RowFlexContainer>
       <UserInviteCard
         key={user.id}
-        id={user.id}
+        stateId={user.id}
+        userId={user.userId}
         bookId={socialId}
         name={user.name}
         link={user.picture}
@@ -84,7 +75,8 @@ const invitationModal: React.FC<Props> = ({ socialId }: Props) => {
     <RowFlexContainer>
       <UserInviteCard
         key={user.id}
-        id={user.id}
+        stateId={user.id}
+        userId={user.userId}
         bookId={socialId}
         name={user.name}
         link={user.picture}
@@ -96,12 +88,13 @@ const invitationModal: React.FC<Props> = ({ socialId }: Props) => {
   ));
 
   useEffect(() => {
-    getWaitedUserList(socialId);
+    getWaitedUserList();
     userCards = userList.map((user) => (
       <RowFlexContainer>
         <UserInviteCard
           key={user.id}
-          id={user.id}
+          stateId={user.id}
+          userId={user.userId}
           bookId={socialId}
           name={user.name}
           link={user.picture}
@@ -115,7 +108,8 @@ const invitationModal: React.FC<Props> = ({ socialId }: Props) => {
       <RowFlexContainer>
         <UserInviteCard
           key={user.id}
-          id={user.id}
+          stateId={user.id}
+          userId={user.userId}
           bookId={socialId}
           name={user.name}
           link={user.picture}

--- a/client/src/components/organisms/InvitationModal/InvitationModal.tsx
+++ b/client/src/components/organisms/InvitationModal/InvitationModal.tsx
@@ -8,6 +8,7 @@ import UserInviteCard from '@molecules/UserInviteCard/UserInviteCard';
 import RowFlexContainer from '@atoms/div/RowFlexContainer';
 import styled from 'styled-components';
 import MyColor from '@theme/color';
+import getRandomKey from '@utils/random';
 
 interface Props {
   socialId: number;
@@ -51,20 +52,14 @@ const invitationModal: React.FC<Props> = ({ socialId }: Props) => {
     setWaitedList(newArgs);
   };
 
-  const callback = () => {
-    return true;
-  };
-
   let userCards: any = userList.map((user) => (
     <RowFlexContainer>
       <UserInviteCard
-        key={user.id}
-        stateId={user.id}
-        userId={user.userId}
+        key={getRandomKey()}
+        userId={user.id}
         bookId={socialId}
         name={user.name}
         link={user.picture}
-        callback={callback}
         backgroundColor={MyColor.primary.skyblue}
         buttonName="초대하기"
       />
@@ -74,13 +69,12 @@ const invitationModal: React.FC<Props> = ({ socialId }: Props) => {
   let waitedCards: any = waitedList.map((user) => (
     <RowFlexContainer>
       <UserInviteCard
-        key={user.id}
+        key={getRandomKey()}
         stateId={user.id}
         userId={user.userId}
         bookId={socialId}
         name={user.name}
         link={user.picture}
-        callback={callback}
         backgroundColor={MyColor.primary.mildGray}
         buttonName="취소"
       />
@@ -92,13 +86,11 @@ const invitationModal: React.FC<Props> = ({ socialId }: Props) => {
     userCards = userList.map((user) => (
       <RowFlexContainer>
         <UserInviteCard
-          key={user.id}
-          stateId={user.id}
-          userId={user.userId}
+          key={getRandomKey()}
+          userId={user.id}
           bookId={socialId}
           name={user.name}
           link={user.picture}
-          callback={callback}
           backgroundColor={MyColor.primary.skyblue}
           buttonName="초대하기"
         />
@@ -107,13 +99,12 @@ const invitationModal: React.FC<Props> = ({ socialId }: Props) => {
     waitedCards = waitedList.map((user) => (
       <RowFlexContainer>
         <UserInviteCard
-          key={user.id}
+          key={getRandomKey()}
           stateId={user.id}
           userId={user.userId}
           bookId={socialId}
           name={user.name}
           link={user.picture}
-          callback={callback}
           backgroundColor={MyColor.primary.mildGray}
           buttonName="취소"
         />

--- a/client/src/components/organisms/SocialAccountBook/SocialAccountBook.tsx
+++ b/client/src/components/organisms/SocialAccountBook/SocialAccountBook.tsx
@@ -65,7 +65,7 @@ const socialAccountBook: React.FC<SocialBook> = ({
   const setSocialId = () => {
     dispatch(setSocial(id));
   };
-  const moveUrl = `/social/edit/:${id}`;
+  const moveUrl = '/social/edit';
   return (
     <>
       <Container onClick={toSocialAccountBook}>

--- a/client/src/components/organisms/SocialAccountBook/SocialAccountBook.tsx
+++ b/client/src/components/organisms/SocialAccountBook/SocialAccountBook.tsx
@@ -61,6 +61,10 @@ const socialAccountBook: React.FC<SocialBook> = ({
     dispatch(initMonth());
     history.push('/accountbook');
   };
+
+  const setSocialId = () => {
+    dispatch(setSocial(id));
+  };
   const moveUrl = `/social/edit/:${id}`;
   return (
     <>
@@ -84,6 +88,7 @@ const socialAccountBook: React.FC<SocialBook> = ({
       {isMaster && (
         <>
           <NavButton
+            onClick={setSocialId}
             moveUrl={moveUrl}
             name="setting"
             width="20%"

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -65,6 +65,9 @@ export const DELETE_SOCIAL_TRANSACTION = (id: number): string =>
 export const DELETE_PRIVATE_TRANSACTION = (id: number): string =>
   `${process.env.REACT_APP_BASE_URL}/api/private/transaction/${id}`;
 
+export const DELETE_SOCIAL_INVITATION = (id: number): string =>
+  `${process.env.REACT_APP_BASE_URL}/api/social/invitation/${id}`;
+
 export const DELETE_PAYMENT = (id: number): string =>
   `${process.env.REACT_APP_BASE_URL}/api/payment/${id}`;
 

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -68,6 +68,9 @@ export const DELETE_PAYMENT = (id: number): string =>
 
 export const GET_INVITATION = `${process.env.REACT_APP_BASE_URL}/api/social/invitation`;
 
+export const GET_SOCIAL_WAITING_USER_LIST = (bookId: number): string =>
+  `${process.env.REACT_APP_BASE_URL}/api/social/invitation/waiting/${bookId}`;
+
 export const GET_SEARCHED_USER_LIST = (name: string): string =>
   `${process.env.REACT_APP_BASE_URL}/api/user/list/${name}`;
 

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -10,6 +10,9 @@ export const GET_TRANSACTION_PRIVATE_LIST = (year: number, month: number): strin
 
 export const GET_USER_INFO = `${process.env.REACT_APP_BASE_URL}/api/user/info`;
 
+export const GET_SOCIAL_BOOK = (bookId: number): string =>
+  `${process.env.REACT_APP_BASE_URL}/api/social/${bookId}`;
+
 export const GET_SOCIAL_BOOKS = `${process.env.REACT_APP_BASE_URL}/api/social/list`;
 
 export const GET_MASTER_BOOKS = `${process.env.REACT_APP_BASE_URL}/api/social/list/master`;

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -41,6 +41,8 @@ export const POST_PRIVATE_TRANSACTION = `${process.env.REACT_APP_BASE_URL}/api/p
 
 export const POST_SOCIAL_TRANSACTION = `${process.env.REACT_APP_BASE_URL}/api/social/transaction`;
 
+export const POST_SOCIAL_INVITATION = `${process.env.REACT_APP_BASE_URL}/api/social/invitation`;
+
 export const GET_PRIVATE_STATISTIC_CATEGORY = (year: number, month: number): string =>
   `${process.env.REACT_APP_BASE_URL}/api/private/statistic/category/${year}/${month}`;
 

--- a/client/src/views/AccountbookEditPage.tsx
+++ b/client/src/views/AccountbookEditPage.tsx
@@ -35,7 +35,7 @@ const AccountbookEditPage: React.FC = () => {
   };
 
   const backgroundColor = colorUtils.getRandomColor();
-  const [inviteArgs, setInviteArgs] = useState<any>(initArgs);
+  const [inviteArgs, setInviteArgs] = useState<InviteProps>(initArgs);
 
   const initAccountbookCard = async () => {
     const { data } = await getAxiosData(API.GET_SOCIAL_BOOK(accountbookId));

--- a/client/src/views/AccountbookEditPage.tsx
+++ b/client/src/views/AccountbookEditPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import ColoredBackground from '@organisms/ColoredBackground';
 import myColor from '@theme/color';
 import CenterContent from '@molecules/CenterContent';
@@ -10,6 +10,8 @@ import styled from 'styled-components';
 import InvitationModal from '@organisms/InvitationModal';
 import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
+import * as API from '@utils/api';
+import { getAxiosData } from '../utils/axios';
 
 interface InviteProps {
   links: string[];
@@ -17,34 +19,42 @@ interface InviteProps {
   name: string;
 }
 
+const initArgs: InviteProps = {
+  links: [
+    'https://avatars2.githubusercontent.com/u/46099115?s=460&u=1e04610d430875d8189d2b212b8c2d9fc268b9db&v=4',
+  ],
+  backgroundColor: myColor.primary.white,
+  name: ' ',
+};
+
 const AccountbookEditPage: React.FC = () => {
   const modalView = useSelector((state: RootState) => state.modal.view);
+  const accountbookId = useSelector((state: RootState) => state.accountbook.socialId);
   const createButtonClick = async (data: any) => {
     console.log(data);
   };
+
+  const backgroundColor = colorUtils.getRandomColor();
+  const [inviteArgs, setInviteArgs] = useState<any>(initArgs);
+
+  const initAccountbookCard = async () => {
+    const { data } = await getAxiosData(API.GET_SOCIAL_BOOK(accountbookId));
+    const newArgs: InviteProps = {
+      links: data.images,
+      backgroundColor: data.color,
+      name: data.name,
+    };
+    setInviteArgs(newArgs);
+  };
+
+  useEffect(() => {
+    initAccountbookCard();
+  }, []);
 
   const SettingContainer = styled.div`
     width = 100%;
     margin-bottom: 1rem;
   `;
-
-  const backgroundColor = colorUtils.getRandomColor();
-
-  // TODO ROUTER 에서 links, backgroudColor, name, socialID 가져오기
-
-  const links = [
-    'https://avatars2.githubusercontent.com/u/46099115?s=460&u=1e04610d430875d8189d2b212b8c2d9fc268b9db&v=4',
-    'https://avatars3.githubusercontent.com/u/55074799?s=460&u=2f70319c2f55ba5e26db060ba21d66a9cab35732&v=4',
-    'https://avatars2.githubusercontent.com/u/50297117?s=460&u=2ddc78ef0045b75f6fb405f1763304a7481d46e4&v=4',
-  ];
-
-  const InviteArgs: InviteProps = {
-    links,
-    backgroundColor: 'yellow',
-    name: '부캠동아리',
-  };
-
-  const id = 2;
 
   return (
     <>
@@ -56,10 +66,10 @@ const AccountbookEditPage: React.FC = () => {
           backgroundColor={backgroundColor}
         />
         <SettingContainer>
-          <InviteAccountbookCard {...InviteArgs} />
+          <InviteAccountbookCard {...inviteArgs} />
         </SettingContainer>
       </CenterContent>
-      {modalView === 'InvitationModal' && <InvitationModal socialId={id} />}
+      {modalView === 'InvitationModal' && <InvitationModal socialId={accountbookId} />}
     </>
   );
 };

--- a/client/src/views/AccountbookEditPage.tsx
+++ b/client/src/views/AccountbookEditPage.tsx
@@ -21,7 +21,7 @@ interface InviteProps {
 
 const initArgs: InviteProps = {
   links: [
-    'https://avatars2.githubusercontent.com/u/46099115?s=460&u=1e04610d430875d8189d2b212b8c2d9fc268b9db&v=4',
+    'https://user-images.githubusercontent.com/50297117/102187552-770b3700-3ef7-11eb-819d-d24c9792a9d7.png',
   ],
   backgroundColor: myColor.primary.white,
   name: ' ',

--- a/client/src/views/AccountbookEditPage.tsx
+++ b/client/src/views/AccountbookEditPage.tsx
@@ -11,7 +11,7 @@ import InvitationModal from '@organisms/InvitationModal';
 import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
 import * as API from '@utils/api';
-import { getAxiosData } from '../utils/axios';
+import { getAxiosData } from '@utils/axios';
 
 interface InviteProps {
   links: string[];


### PR DESCRIPTION
### 📕 Issue Number

Close #104, #105 

<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- social id store 설정

- accountBookEditPage socialId 적용

- 초대 대기 유저 목록 api 연동

- invitation 초대 api 연동

- invitation 취소 api 연결

- 초대 모달 상태 구현

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 소셜 가계부 수정페이지 진입시 설정버튼 클릭-> social id store update 를 진행하기 때문에, 수정페이지에서 새로고침을 하면 store가 초기화되어 데이터를 불러올 수 없는 문제가 있습니다.
- 해결방안 으로는 localstorage 사용해서 store 캐싱하는 방법, router 설정으로 새로고침시 메인으로 이동하는 방법이 있을 것 같습니다.

<br/><br/>