### PR TITLE
FE-feat-수정페이지 완성

### DIFF
--- a/client/src/components/organisms/CreateAccountbookColorModal/CreateAccountbookColorModal.tsx
+++ b/client/src/components/organisms/CreateAccountbookColorModal/CreateAccountbookColorModal.tsx
@@ -44,7 +44,6 @@ const CreateAccountbookColorModal: React.FC<Props> = ({ buttonEvent, currentColo
 
   useEffect(() => {
     nowColor = colorList[curIndex[0]][curIndex[1]];
-    console.log(nowColor);
   }, [curIndex]);
 
   const selectColor = (color) => {

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.stories.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.stories.tsx
@@ -15,6 +15,8 @@ const testFunc = (name: any, description: any) => {
 export const createAccountbookFormBox = (): JSX.Element => {
   return (
     <CreateAccountbookFormBox
+      // eslint-disable-next-line jsx-a11y/aria-role
+      role="생성"
       buttonEvent={testFunc('슈퍼가계부', '슈퍼가계부 입니다')}
       backgroundColor={myColor.primary.main}
     />

--- a/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
+++ b/client/src/components/organisms/CreateAccountbookFormBox/CreateAccountbookFormBox.tsx
@@ -8,14 +8,19 @@ import RoundShortButton from '@atoms/button/RoundShortButton';
 import colorUtils from '@utils/color';
 
 interface Props {
+  role: string;
   backgroundColor: string;
   buttonEvent: (name, description) => any;
 }
 
-const CreateAccountbookFormBox: React.FC<Props> = ({ buttonEvent, backgroundColor }: Props) => {
+const CreateAccountbookFormBox: React.FC<Props> = ({
+  role,
+  buttonEvent,
+  backgroundColor,
+}: Props) => {
   const fontColor = colorUtils.getFontColor(backgroundColor);
   const buttonColor = fontColor === 'white' ? 'black' : 'white';
-
+  const title = `가계부 ${role}`;
   const [name, setName] = useState();
   const [description, setDescription] = useState();
 
@@ -38,7 +43,7 @@ const CreateAccountbookFormBox: React.FC<Props> = ({ buttonEvent, backgroundColo
       >
         <RowFlexContainer width="100%" justifyContent="space-between">
           <LeftLargeText color={fontColor} fontWeight="bold">
-            가계부 생성
+            {title}
           </LeftLargeText>
           <RoundShortButton
             border="none"
@@ -46,7 +51,7 @@ const CreateAccountbookFormBox: React.FC<Props> = ({ buttonEvent, backgroundColo
             color={fontColor}
             onClick={() => buttonEvent(name, description)}
           >
-            생성
+            {role}
           </RoundShortButton>
         </RowFlexContainer>
         <RowFlexContainer width="100%" justifyContent="baseline">

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -84,3 +84,6 @@ export const GET_SEARCHED_USER_LIST = (name: string): string =>
 
 export const PATCH_INVITATION = (id: number): string =>
   `${process.env.REACT_APP_BASE_URL}/api/social/invitation/${id}`;
+
+export const PATCH_SOCIAL_ACCOUNTBOOK = (bookId: number): string =>
+  `${process.env.REACT_APP_BASE_URL}/api/social/${bookId}`;

--- a/client/src/views/AccountbookEditPage.tsx
+++ b/client/src/views/AccountbookEditPage.tsx
@@ -5,13 +5,16 @@ import CenterContent from '@molecules/CenterContent';
 import CreateAccountbookFormBox from '@organisms/CreateAccountbookFormBox';
 import TopNavBar from '@organisms/TopNavBar';
 import InviteAccountbookCard from '@molecules/InviteAccountbookCard';
-import colorUtils from '@utils/color';
+// import colorUtils from '@utils/color';
+// import getColorList from '@theme/colorList';
 import styled from 'styled-components';
 import InvitationModal from '@organisms/InvitationModal';
 import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
 import * as API from '@utils/api';
 import { getAxiosData } from '@utils/axios';
+import CreateAccountbookColorModal from '@organisms/CreateAccountbookColorModal';
+import CreateAccountbookSetting from '@organisms/CreateAccountbookSetting';
 
 interface InviteProps {
   links: string[];
@@ -27,15 +30,15 @@ const initArgs: InviteProps = {
   name: ' ',
 };
 
-let backgroundColor = colorUtils.getRandomColor();
+// const backgroundColor = colorUtils.getRandomColorInList(getColorList());
 
 const AccountbookEditPage: React.FC = () => {
   const modalView = useSelector((state: RootState) => state.modal.view);
   const accountbookId = useSelector((state: RootState) => state.accountbook.socialId);
-  // const [accountbookMainColor, setAccountbookMainColor] = useState(backgroundColor)
+  const [accountbookMainColor, setAccountbookMainColor] = useState('#FF0000');
 
-  const editButtonClick = async (data: any) => {
-    console.log(data);
+  const editButtonClick = async (name: string, description: string) => {
+    console.log(name, description, accountbookMainColor);
   };
 
   const [inviteArgs, setInviteArgs] = useState<InviteProps>(initArgs);
@@ -47,7 +50,7 @@ const AccountbookEditPage: React.FC = () => {
       backgroundColor: data.color,
       name: data.name,
     };
-    backgroundColor = data.color;
+    setAccountbookMainColor(data.color);
     setInviteArgs(newArgs);
   };
 
@@ -60,17 +63,34 @@ const AccountbookEditPage: React.FC = () => {
     margin-bottom: 1rem;
   `;
 
+  const getAccountbookMainColor = (color) => {
+    setAccountbookMainColor(color);
+    inviteArgs.backgroundColor = color;
+    setInviteArgs(inviteArgs);
+  };
+
   return (
     <>
       <ColoredBackground backgroundColor={myColor.primary.lightGray} />
       <CenterContent>
-        <TopNavBar backgroundColor={backgroundColor} />
-        <CreateAccountbookFormBox buttonEvent={editButtonClick} backgroundColor={backgroundColor} />
+        <TopNavBar backgroundColor={accountbookMainColor} />
+        <CreateAccountbookFormBox
+          // buttonName="수정"
+          buttonEvent={editButtonClick}
+          backgroundColor={accountbookMainColor}
+        />
         <SettingContainer>
           <InviteAccountbookCard {...inviteArgs} />
+          <CreateAccountbookSetting labelColor={accountbookMainColor} />
         </SettingContainer>
       </CenterContent>
       {modalView === 'InvitationModal' && <InvitationModal socialId={accountbookId} />}
+      {modalView === 'CreateAccountbookColor' && (
+        <CreateAccountbookColorModal
+          buttonEvent={getAccountbookMainColor}
+          currentColor={accountbookMainColor}
+        />
+      )}
     </>
   );
 };

--- a/client/src/views/AccountbookEditPage.tsx
+++ b/client/src/views/AccountbookEditPage.tsx
@@ -75,7 +75,8 @@ const AccountbookEditPage: React.FC = () => {
       <CenterContent>
         <TopNavBar backgroundColor={accountbookMainColor} />
         <CreateAccountbookFormBox
-          // buttonName="수정"
+          // eslint-disable-next-line jsx-a11y/aria-role
+          role="수정"
           buttonEvent={editButtonClick}
           backgroundColor={accountbookMainColor}
         />

--- a/client/src/views/AccountbookEditPage.tsx
+++ b/client/src/views/AccountbookEditPage.tsx
@@ -27,14 +27,17 @@ const initArgs: InviteProps = {
   name: ' ',
 };
 
+let backgroundColor = colorUtils.getRandomColor();
+
 const AccountbookEditPage: React.FC = () => {
   const modalView = useSelector((state: RootState) => state.modal.view);
   const accountbookId = useSelector((state: RootState) => state.accountbook.socialId);
-  const createButtonClick = async (data: any) => {
+  // const [accountbookMainColor, setAccountbookMainColor] = useState(backgroundColor)
+
+  const editButtonClick = async (data: any) => {
     console.log(data);
   };
 
-  const backgroundColor = colorUtils.getRandomColor();
   const [inviteArgs, setInviteArgs] = useState<InviteProps>(initArgs);
 
   const initAccountbookCard = async () => {
@@ -44,6 +47,7 @@ const AccountbookEditPage: React.FC = () => {
       backgroundColor: data.color,
       name: data.name,
     };
+    backgroundColor = data.color;
     setInviteArgs(newArgs);
   };
 
@@ -61,10 +65,7 @@ const AccountbookEditPage: React.FC = () => {
       <ColoredBackground backgroundColor={myColor.primary.lightGray} />
       <CenterContent>
         <TopNavBar backgroundColor={backgroundColor} />
-        <CreateAccountbookFormBox
-          buttonEvent={createButtonClick}
-          backgroundColor={backgroundColor}
-        />
+        <CreateAccountbookFormBox buttonEvent={editButtonClick} backgroundColor={backgroundColor} />
         <SettingContainer>
           <InviteAccountbookCard {...inviteArgs} />
         </SettingContainer>

--- a/client/src/views/AccountbookEditPage.tsx
+++ b/client/src/views/AccountbookEditPage.tsx
@@ -5,14 +5,13 @@ import CenterContent from '@molecules/CenterContent';
 import CreateAccountbookFormBox from '@organisms/CreateAccountbookFormBox';
 import TopNavBar from '@organisms/TopNavBar';
 import InviteAccountbookCard from '@molecules/InviteAccountbookCard';
-// import colorUtils from '@utils/color';
-// import getColorList from '@theme/colorList';
 import styled from 'styled-components';
 import InvitationModal from '@organisms/InvitationModal';
 import { useSelector } from 'react-redux';
 import { RootState } from '@reducers/rootReducer';
+import { useHistory } from 'react-router-dom';
 import * as API from '@utils/api';
-import { getAxiosData } from '@utils/axios';
+import { getAxiosData, patchAxios } from '@utils/axios';
 import CreateAccountbookColorModal from '@organisms/CreateAccountbookColorModal';
 import CreateAccountbookSetting from '@organisms/CreateAccountbookSetting';
 
@@ -30,15 +29,20 @@ const initArgs: InviteProps = {
   name: ' ',
 };
 
-// const backgroundColor = colorUtils.getRandomColorInList(getColorList());
-
 const AccountbookEditPage: React.FC = () => {
   const modalView = useSelector((state: RootState) => state.modal.view);
   const accountbookId = useSelector((state: RootState) => state.accountbook.socialId);
   const [accountbookMainColor, setAccountbookMainColor] = useState('#FF0000');
+  const history = useHistory();
 
   const editButtonClick = async (name: string, description: string) => {
-    console.log(name, description, accountbookMainColor);
+    const data = {
+      name,
+      description,
+      color: accountbookMainColor,
+    };
+    await patchAxios(API.PATCH_SOCIAL_ACCOUNTBOOK(accountbookId), data);
+    history.push('/');
   };
 
   const [inviteArgs, setInviteArgs] = useState<InviteProps>(initArgs);

--- a/client/src/views/CreateAccountbookPage.tsx
+++ b/client/src/views/CreateAccountbookPage.tsx
@@ -48,6 +48,8 @@ const CreateAccountbookPage: React.FC = () => {
       <CenterContent>
         <TopNavBar backgroundColor={accountbookMainColor} />
         <CreateAccountbookFormBox
+          // eslint-disable-next-line jsx-a11y/aria-role
+          role="생성"
           buttonEvent={createButtonClick}
           backgroundColor={accountbookMainColor}
         />


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- 색상 모달 적용 
    - @JunYoung7  
    - 준영님이 제작해주신 모달과 상태관리를 활용 했습니다.

- edit page accountbook color 연동
![](https://i.imgur.com/3pj8cKx.png)

    - 기존에 소셜가계부 색상으로 Edit 페이지 진입시 전체 색상을 변경해 주었습니다.
    - 색상 변경시 상단과 가계부에도 동시에 색상을 변경하도록 수정했습니다.

- 생성/수정 구분 role props 추가
    - 가계부 생성페이지와 수정페이지의 컴포넌트 재사용을 위해 추가했습니다.

- Patch Axios 연결, 소셜가계부 페이지 구현
![](https://i.imgur.com/HQaqvhV.png)
    - Patch API 로 색상변경, title 변경, description 변경 적용을 확인했습니다.

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 리펙토링


<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- title, description의 값이 없을때 예외처리가 필요할 것 같습니다.

<br/><br/>